### PR TITLE
좋아요 API 구현

### DIFF
--- a/src/main/java/com/example/picket/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/picket/common/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
     LIKE_NOT_FOUND(NOT_FOUND, "해당 좋아요를 찾을 수 없습니다."),
     LIKE_REQUEST_USER_MISMATCH(BAD_REQUEST, "해당 좋아요를 누른 사용자와 요청한 사용자가 다릅니다."),
     LIKE_REQUEST_SHOW_MISMATCH(BAD_REQUEST, "해당 좋아요가 눌린 공연과 요청된 공연이 다릅니다."),
+    LIKE_ALREADY_EXIST(BAD_REQUEST, "이미 해당 좋아요를 눌렀습니다."),
+
     // SEAT
 
 
@@ -48,7 +50,7 @@ public enum ErrorCode {
     USER_PASSWORD_INVALID(UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     USER_NOT_FOUND(NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
 
-    ;
+   ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/picket/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/picket/common/exception/ErrorCode.java
@@ -27,13 +27,14 @@ public enum ErrorCode {
     GRADE_TYPE_INVALID(BAD_REQUEST, "유효하지 않은 등급 유형입니다."),
 
     // LIKE
-
-
+    LIKE_NOT_FOUND(NOT_FOUND, "해당 좋아요를 찾을 수 없습니다."),
+    LIKE_REQUEST_USER_MISMATCH(BAD_REQUEST, "해당 좋아요를 누른 사용자와 요청한 사용자가 다릅니다."),
+    LIKE_REQUEST_SHOW_MISMATCH(BAD_REQUEST, "해당 좋아요가 눌린 공연과 요청된 공연이 다릅니다."),
     // SEAT
 
 
     // SHOW
-
+    SHOW_NOT_FOUND(NOT_FOUND, "해당 공연을 찾을 수 없습니다."),
 
     // SHOW_DATE
 

--- a/src/main/java/com/example/picket/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/picket/domain/like/controller/LikeController.java
@@ -1,0 +1,29 @@
+package com.example.picket.domain.like.controller;
+
+import com.example.picket.common.annotation.Auth;
+import com.example.picket.common.dto.AuthUser;
+import com.example.picket.domain.like.dto.response.LikeResponse;
+import com.example.picket.domain.like.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @GetMapping("/likes")
+    public ResponseEntity<Page<LikeResponse>> getLikes(@RequestParam(defaultValue = "0") int page,
+                                                       @RequestParam(defaultValue = "10") int size,
+                                                       @Auth AuthUser authUser) {
+        Page<LikeResponse> responses = likeService.getLikes(authUser, page, size);
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/com/example/picket/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/picket/domain/like/controller/LikeController.java
@@ -5,8 +5,13 @@ import com.example.picket.common.dto.AuthUser;
 import com.example.picket.domain.like.dto.response.LikeResponse;
 import com.example.picket.domain.like.service.LikeCommandService;
 import com.example.picket.domain.like.service.LikeQueryService;
+import com.example.picket.domain.show.entity.Show;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,8 +34,17 @@ public class LikeController {
     public ResponseEntity<Page<LikeResponse>> getLikes(@RequestParam(defaultValue = "0") int page,
                                                        @RequestParam(defaultValue = "10") int size,
                                                        @Auth AuthUser authUser) {
-        Page<LikeResponse> responses = likeQueryService.getLikes(authUser.getId(), page, size);
-
+        List<Show> shows = likeQueryService.getLikes(authUser.getId(), page, size);
+        Pageable pageable = PageRequest.of(page, size);
+        List<LikeResponse> likeResponses = shows.stream().map(
+                show -> LikeResponse.toDto(
+                        show.getId(),
+                        show.getTitle(),
+                        show.getCategory(),
+                        show.getDescription()
+                )
+        ).toList();
+        Page<LikeResponse> responses = new PageImpl<>(likeResponses, pageable, likeResponses.size());
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/com/example/picket/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/picket/domain/like/controller/LikeController.java
@@ -3,11 +3,16 @@ package com.example.picket.domain.like.controller;
 import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.domain.like.dto.response.LikeResponse;
-import com.example.picket.domain.like.service.LikeService;
+import com.example.picket.domain.like.service.LikeCommandService;
+import com.example.picket.domain.like.service.LikeQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,13 +22,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LikeController {
 
-    private final LikeService likeService;
+    private final LikeQueryService likeQueryService;
+    private final LikeCommandService likeCommandService;
 
     @GetMapping("/likes")
     public ResponseEntity<Page<LikeResponse>> getLikes(@RequestParam(defaultValue = "0") int page,
                                                        @RequestParam(defaultValue = "10") int size,
                                                        @Auth AuthUser authUser) {
-        Page<LikeResponse> responses = likeService.getLikes(authUser, page, size);
+        Page<LikeResponse> responses = likeQueryService.getLikes(authUser, page, size);
         return ResponseEntity.ok(responses);
+    }
+
+    @PostMapping("/shows/{showId}/likes")
+    public ResponseEntity<Void> createLike(@Auth AuthUser authUser, @PathVariable Long showId) {
+        likeCommandService.createLike(authUser, showId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/shows/{showId}/likes/{likeId}")
+    public ResponseEntity<Void> createLike(@Auth AuthUser authUser, @PathVariable Long showId,
+                                           @PathVariable Long likeId) {
+        likeCommandService.deleteLike(authUser, showId, likeId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/picket/domain/like/controller/LikeController.java
@@ -29,20 +29,21 @@ public class LikeController {
     public ResponseEntity<Page<LikeResponse>> getLikes(@RequestParam(defaultValue = "0") int page,
                                                        @RequestParam(defaultValue = "10") int size,
                                                        @Auth AuthUser authUser) {
-        Page<LikeResponse> responses = likeQueryService.getLikes(authUser, page, size);
+        Page<LikeResponse> responses = likeQueryService.getLikes(authUser.getId(), page, size);
+
         return ResponseEntity.ok(responses);
     }
 
     @PostMapping("/shows/{showId}/likes")
     public ResponseEntity<Void> createLike(@Auth AuthUser authUser, @PathVariable Long showId) {
-        likeCommandService.createLike(authUser, showId);
+        likeCommandService.createLike(authUser.getId(), showId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @DeleteMapping("/shows/{showId}/likes/{likeId}")
     public ResponseEntity<Void> createLike(@Auth AuthUser authUser, @PathVariable Long showId,
                                            @PathVariable Long likeId) {
-        likeCommandService.deleteLike(authUser, showId, likeId);
+        likeCommandService.deleteLike(authUser.getId(), showId, likeId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/example/picket/domain/like/dto/response/LikeResponse.java
@@ -1,7 +1,6 @@
 package com.example.picket.domain.like.dto.response;
 
 import com.example.picket.common.enums.Category;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -12,11 +11,14 @@ public class LikeResponse {
     private final Category category;
     private final String description;
 
-    @Builder
     private LikeResponse(Long showId, String showTitle, Category category, String description) {
         this.showId = showId;
         this.showTitle = showTitle;
         this.category = category;
         this.description = description;
+    }
+
+    public static LikeResponse toDto(Long showId, String showTitle, Category category, String description) {
+        return new LikeResponse(showId, showTitle, category, description);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/example/picket/domain/like/dto/response/LikeResponse.java
@@ -1,0 +1,22 @@
+package com.example.picket.domain.like.dto.response;
+
+import com.example.picket.common.enums.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LikeResponse {
+
+    private final Long showId;
+    private final String showTitle;
+    private final Category category;
+    private final String description;
+
+    @Builder
+    private LikeResponse(Long showId, String showTitle, Category category, String description) {
+        this.showId = showId;
+        this.showTitle = showTitle;
+        this.category = category;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/picket/domain/like/entity/Like.java
+++ b/src/main/java/com/example/picket/domain/like/entity/Like.java
@@ -1,6 +1,5 @@
 package com.example.picket.domain.like.entity;
 
-import com.example.picket.common.entity.BaseEntity;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.user.entity.User;
 import jakarta.persistence.Entity;
@@ -12,7 +11,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,9 +32,12 @@ public class Like {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Builder
     private Like(Show show, User user) {
         this.show = show;
         this.user = user;
+    }
+
+    public static Like toEntity(Show show, User user) {
+        return new Like(show, user);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/picket/domain/like/repository/LikeRepository.java
@@ -2,8 +2,10 @@ package com.example.picket.domain.like.repository;
 
 import com.example.picket.domain.like.dto.response.LikeResponse;
 import com.example.picket.domain.like.entity.Like;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,4 +14,12 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     @Query("SELECT new com.example.picket.domain.like.dto.response.LikeResponse(s.id, s.title, s.category, s.description) " +
             "FROM Like l JOIN l.show s WHERE l.user.id = :id")
     Page<LikeResponse> findLikesWithShowByUserId(Long id, Pageable pageable);
+
+    @EntityGraph(
+            attributePaths = {
+                    "user",
+                    "show"
+            }
+    )
+    Optional<Like> findWithUserAndShowById(Long likeId);
 }

--- a/src/main/java/com/example/picket/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/picket/domain/like/repository/LikeRepository.java
@@ -22,4 +22,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
             }
     )
     Optional<Like> findWithUserAndShowById(Long likeId);
+
+    boolean existsByUserIdAndShowId(Long userId, Long showId);
 }

--- a/src/main/java/com/example/picket/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/picket/domain/like/repository/LikeRepository.java
@@ -1,19 +1,20 @@
 package com.example.picket.domain.like.repository;
 
-import com.example.picket.domain.like.dto.response.LikeResponse;
 import com.example.picket.domain.like.entity.Like;
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-    @Query("SELECT new com.example.picket.domain.like.dto.response.LikeResponse(s.id, s.title, s.category, s.description) " +
-            "FROM Like l JOIN l.show s WHERE l.user.id = :id")
-    Page<LikeResponse> findLikesWithShowByUserId(Long id, Pageable pageable);
+    @EntityGraph(
+            attributePaths = {
+                    "show"
+            }
+    )
+    List<Like> findLikesByUserId(Long id, Pageable pageable);
 
     @EntityGraph(
             attributePaths = {

--- a/src/main/java/com/example/picket/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/picket/domain/like/repository/LikeRepository.java
@@ -1,7 +1,15 @@
 package com.example.picket.domain.like.repository;
 
+import com.example.picket.domain.like.dto.response.LikeResponse;
 import com.example.picket.domain.like.entity.Like;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    @Query("SELECT new com.example.picket.domain.like.dto.response.LikeResponse(s.id, s.title, s.category, s.description) " +
+            "FROM Like l JOIN l.show s WHERE l.user.id = :id")
+    Page<LikeResponse> findLikesWithShowByUserId(Long id, Pageable pageable);
 }

--- a/src/main/java/com/example/picket/domain/like/service/LikeCommandService.java
+++ b/src/main/java/com/example/picket/domain/like/service/LikeCommandService.java
@@ -33,16 +33,14 @@ public class LikeCommandService {
             throw new CustomException(ErrorCode.LIKE_ALREADY_EXIST);
         }
 
-        Like like = Like.builder()
-                .user(user)
-                .show(show)
-                .build();
-
+        Like like = Like.toEntity(show, user);
+        
         likeRepository.save(like);
     }
 
     public void deleteLike(Long userId, Long showId, Long likeId) {
-        Like like = likeRepository.findWithUserAndShowById(likeId).orElseThrow(() -> new CustomException(ErrorCode.LIKE_NOT_FOUND));
+        Like like = likeRepository.findWithUserAndShowById(likeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.LIKE_NOT_FOUND));
 
         if (!Objects.equals(like.getUser().getId(), userId)) {
             throw new CustomException(ErrorCode.LIKE_REQUEST_USER_MISMATCH);

--- a/src/main/java/com/example/picket/domain/like/service/LikeCommandService.java
+++ b/src/main/java/com/example/picket/domain/like/service/LikeCommandService.java
@@ -1,0 +1,54 @@
+package com.example.picket.domain.like.service;
+
+import com.example.picket.common.dto.AuthUser;
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.common.exception.ErrorCode;
+import com.example.picket.domain.like.entity.Like;
+import com.example.picket.domain.like.repository.LikeRepository;
+import com.example.picket.domain.show.entity.Show;
+import com.example.picket.domain.show.repository.ShowRepository;
+import com.example.picket.domain.user.entity.User;
+import com.example.picket.domain.user.repository.UserRepository;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikeCommandService {
+
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final ShowRepository showRepository;
+
+
+    public void createLike(AuthUser authUser, Long showId) {
+        User user = userRepository.findById(authUser.getId()).orElseThrow(() -> new CustomException(
+                ErrorCode.USER_NOT_FOUND));
+
+        Show show = showRepository.findById(showId).orElseThrow(() -> new CustomException(ErrorCode.SHOW_NOT_FOUND));
+
+        Like like = Like.builder()
+                .user(user)
+                .show(show)
+                .build();
+
+        likeRepository.save(like);
+    }
+
+    public void deleteLike(AuthUser authUser, Long showId, Long likeId) {
+        Like like = likeRepository.findWithUserAndShowById(likeId).orElseThrow(() -> new CustomException(ErrorCode.LIKE_NOT_FOUND));
+
+        if (!Objects.equals(like.getUser().getId(), authUser.getId())) {
+            throw new CustomException(ErrorCode.LIKE_REQUEST_USER_MISMATCH);
+        }
+
+        if (!Objects.equals(like.getShow().getId(), showId)) {
+            throw new CustomException(ErrorCode.LIKE_REQUEST_SHOW_MISMATCH);
+        }
+
+        likeRepository.delete(like);
+    }
+}

--- a/src/main/java/com/example/picket/domain/like/service/LikeCommandService.java
+++ b/src/main/java/com/example/picket/domain/like/service/LikeCommandService.java
@@ -1,6 +1,5 @@
 package com.example.picket.domain.like.service;
 
-import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.common.exception.ErrorCode;
 import com.example.picket.domain.like.entity.Like;
@@ -24,11 +23,15 @@ public class LikeCommandService {
     private final ShowRepository showRepository;
 
 
-    public void createLike(AuthUser authUser, Long showId) {
-        User user = userRepository.findById(authUser.getId()).orElseThrow(() -> new CustomException(
+    public void createLike(Long userId, Long showId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(
                 ErrorCode.USER_NOT_FOUND));
 
         Show show = showRepository.findById(showId).orElseThrow(() -> new CustomException(ErrorCode.SHOW_NOT_FOUND));
+
+        if (likeRepository.existsByUserIdAndShowId(user.getId(), show.getId())) {
+            throw new CustomException(ErrorCode.LIKE_ALREADY_EXIST);
+        }
 
         Like like = Like.builder()
                 .user(user)
@@ -38,10 +41,10 @@ public class LikeCommandService {
         likeRepository.save(like);
     }
 
-    public void deleteLike(AuthUser authUser, Long showId, Long likeId) {
+    public void deleteLike(Long userId, Long showId, Long likeId) {
         Like like = likeRepository.findWithUserAndShowById(likeId).orElseThrow(() -> new CustomException(ErrorCode.LIKE_NOT_FOUND));
 
-        if (!Objects.equals(like.getUser().getId(), authUser.getId())) {
+        if (!Objects.equals(like.getUser().getId(), userId)) {
             throw new CustomException(ErrorCode.LIKE_REQUEST_USER_MISMATCH);
         }
 

--- a/src/main/java/com/example/picket/domain/like/service/LikeQueryService.java
+++ b/src/main/java/com/example/picket/domain/like/service/LikeQueryService.java
@@ -8,10 +8,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class LikeService {
+@Transactional(readOnly = true)
+public class LikeQueryService {
 
     private final LikeRepository likeRepository;
 

--- a/src/main/java/com/example/picket/domain/like/service/LikeQueryService.java
+++ b/src/main/java/com/example/picket/domain/like/service/LikeQueryService.java
@@ -1,6 +1,5 @@
 package com.example.picket.domain.like.service;
 
-import com.example.picket.common.dto.AuthUser;
 import com.example.picket.domain.like.dto.response.LikeResponse;
 import com.example.picket.domain.like.repository.LikeRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +16,8 @@ public class LikeQueryService {
 
     private final LikeRepository likeRepository;
 
-    public Page<LikeResponse> getLikes(AuthUser authUser, int page, int size) {
+    public Page<LikeResponse> getLikes(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        return likeRepository.findLikesWithShowByUserId(authUser.getId(), pageable);
+        return likeRepository.findLikesWithShowByUserId(userId, pageable);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/service/LikeQueryService.java
+++ b/src/main/java/com/example/picket/domain/like/service/LikeQueryService.java
@@ -1,9 +1,11 @@
 package com.example.picket.domain.like.service;
 
-import com.example.picket.domain.like.dto.response.LikeResponse;
+import com.example.picket.domain.like.entity.Like;
 import com.example.picket.domain.like.repository.LikeRepository;
+import com.example.picket.domain.show.entity.Show;
+import com.example.picket.domain.show.repository.ShowRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,9 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeQueryService {
 
     private final LikeRepository likeRepository;
+    private final ShowRepository showRepository;
 
-    public Page<LikeResponse> getLikes(Long userId, int page, int size) {
+    public List<Show> getLikes(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        return likeRepository.findLikesWithShowByUserId(userId, pageable);
+        List<Like> likeList = likeRepository.findLikesByUserId(userId, pageable);
+        List<Long> showId = likeList.stream().map(
+                like -> {
+                    return like.getShow().getId();
+                }
+        ).toList();
+
+        return showRepository.findAllById(showId);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/service/LikeService.java
+++ b/src/main/java/com/example/picket/domain/like/service/LikeService.java
@@ -1,0 +1,22 @@
+package com.example.picket.domain.like.service;
+
+import com.example.picket.common.dto.AuthUser;
+import com.example.picket.domain.like.dto.response.LikeResponse;
+import com.example.picket.domain.like.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public Page<LikeResponse> getLikes(AuthUser authUser, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return likeRepository.findLikesWithShowByUserId(authUser.getId(), pageable);
+    }
+}


### PR DESCRIPTION
### 📌 반영 브랜치
feat/like -> dev

### ✅ 작업 내용
- 사용자가 좋아요한 공연 조회 API 구현
- 좋아요 추가 API 구현
- 좋아요 취소 API 구현
- Service 메서드에서 Entity 반환할 수 있도록 수정
- Static Factory Method 적용

### 🎯 단독 테스트 결과
-> Postman을 통해 정상적으로 동작하는지 확인 완료

### 🚨 연관 이슈
closes #27
closes #28
closes #29