### PR TITLE
인증/인가 API 인터셉터 관련 수정

### DIFF
--- a/src/main/java/com/example/picket/common/consts/Const.java
+++ b/src/main/java/com/example/picket/common/consts/Const.java
@@ -1,12 +1,28 @@
 package com.example.picket.common.consts;
 
-import java.util.List;
+import java.util.Map;
 
 public interface Const {
 
     String PASSWORD_PATTERN = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$";
-    
-    //TODO : 추후 로그인 없이도 방문가능한 페이지의 경우 해당 화이트 리스트에 URL 추가
-    List<String> WHITE_LIST = List.of("/api/v1/auth/signup/*", "/api/v1/auth/signin");
 
+    //TODO : 추후 로그인 없이도 방문가능한 페이지의 경우 해당 화이트 리스트에 URL 추가
+    Map<String, String[]> WHITE_LIST = Map.of(
+            "GET", new String[]{
+
+            },
+            "POST", new String[]{
+                    "/api/v1/auth/signup/*",
+                    "/api/v1/auth/signin",
+            },
+            "PUT", new String[]{
+
+            },
+            "PATCH", new String[]{
+
+            },
+            "DELETE", new String[]{
+
+            }
+    );
 }

--- a/src/main/java/com/example/picket/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/example/picket/common/interceptor/AuthInterceptor.java
@@ -1,11 +1,13 @@
 package com.example.picket.common.interceptor;
 
+import com.example.picket.common.consts.Const;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.common.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Component;
+import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
@@ -15,10 +17,26 @@ public class AuthInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         HttpSession session = request.getSession(false);
 
+        String requestMethod = request.getMethod();
+        String requestUri = request.getRequestURI();
+
+        if (isWhiteList(requestMethod, requestUri)) {
+            return true;
+        }
+
         if (session == null) {
             throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED_LOGIN);
         }
 
         return true;
+    }
+
+    private boolean isWhiteList(String method, String path) {
+        if (!Const.WHITE_LIST.containsKey(method)) {
+            return false;
+        }
+
+        String[] lists = Const.WHITE_LIST.get(method);
+        return PatternMatchUtils.simpleMatch(lists, path);
     }
 }

--- a/src/main/java/com/example/picket/config/WebConfig.java
+++ b/src/main/java/com/example/picket/config/WebConfig.java
@@ -1,7 +1,6 @@
 package com.example.picket.config;
 
 import com.example.picket.common.auth.AuthUserArgumentResolver;
-import com.example.picket.common.consts.Const;
 import com.example.picket.common.interceptor.AuthInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
-                .addPathPatterns("/api/**")
-                .excludePathPatterns(Const.WHITE_LIST);
+                .addPathPatterns("/api/**");
     }
 
     @Override


### PR DESCRIPTION
### 📌 반영 브랜치
feat/auth -> dev

### ✅ 작업 내용
- WHITE_LIST를 POST, GET, DELETE, PUT, PATCH 별로 관리할 수 있도록 수정.
- 이에따라 AuthInterceptor도 화이트리스트 적용가능하도록 수정

### 🎯 단독 테스트 결과
-> Postman을 통해 정상적으로 동작하는지 확인 완료

### 🚨 연관 이슈
closes #24 