### PR TITLE
티켓 테스트 코드 작성, 티켓 생성 시 N+1 문제 해결, yml 수정

### DIFF
--- a/src/main/java/com/example/picket/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/example/picket/domain/seat/repository/SeatRepository.java
@@ -5,11 +5,12 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
     List<Seat> findAllByShowDateId(Long showDateId);
 
-    @Query("SELECT s FROM Seat s JOIN FETCH s.showDate sd JOIN FETCH sd.show WHERE s.id = :id")
-    Optional<Seat> findByIdWithShowDateAndShow(Long id);
+    @Query("SELECT s FROM Seat s JOIN FETCH s.showDate sd JOIN FETCH sd.show WHERE s.id = :seatId")
+    Optional<Seat> findByIdWithShowDateAndShow(@Param("seatId") Long seatId);
 }

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
@@ -41,7 +41,7 @@ public class TicketCommandService {
 
         User foundUser = getUser(userId);
         BigDecimal foundPrice = foundSeat.getPrice();
-        ShowDate foundShowDate = getShowDate(foundShow);
+        ShowDate foundShowDate = foundSeat.getShowDate();
 
         discountShowDateRemainCount(foundShowDate);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect

--- a/src/test/java/com/example/picket/domain/ticket/service/TicketCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ticket/service/TicketCommandServiceTest.java
@@ -1,0 +1,212 @@
+package com.example.picket.domain.ticket.service;
+
+import com.example.picket.common.enums.TicketStatus;
+import com.example.picket.common.enums.UserRole;
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.common.exception.ErrorCode;
+import com.example.picket.domain.seat.entity.Seat;
+import com.example.picket.domain.seat.service.SeatQueryService;
+import com.example.picket.domain.show.entity.Show;
+import com.example.picket.domain.show.entity.ShowDate;
+import com.example.picket.domain.show.service.ShowDateQueryService;
+import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.ticket.repository.TicketRepository;
+import com.example.picket.domain.user.entity.User;
+import com.example.picket.domain.user.service.UserQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TicketCommandServiceTest {
+
+    @Mock
+    private TicketRepository ticketRepository;
+    @Mock
+    private UserQueryService userQueryService;
+    @Mock
+    private SeatQueryService seatQueryService;
+    @Mock
+    private ShowDateQueryService showDateQueryService;
+
+    @InjectMocks
+    private TicketCommandService ticketCommandService;
+
+    private final Long userId = 1L;
+    private final Long seatId = 2L;
+    private final Long ticketId = 3L;
+
+    @Test
+    void 티켓을_생성할_수_있다() {
+
+        // given
+        Seat seat = mock(Seat.class);
+        Show show = mock(Show.class);
+        ShowDate showDate = mock(ShowDate.class);
+        User user = mock(User.class);
+
+        when(seatQueryService.findById(seatId)).thenReturn(seat);
+        when(seat.getShowDate()).thenReturn(showDate);
+        when(showDate.getShow()).thenReturn(show);
+        when(show.getReservationStart()).thenReturn(LocalDateTime.now().minusHours(1));
+        when(show.getReservationEnd()).thenReturn(LocalDateTime.now().plusHours(1));
+        when(ticketRepository.existsBySeat(seat)).thenReturn(false);
+        when(userQueryService.findById(userId)).thenReturn(user);
+        when(seat.getPrice()).thenReturn(BigDecimal.valueOf(10000));
+        when(seat.getShowDate()).thenReturn(showDate);
+
+        Ticket ticket = mock(Ticket.class);
+        when(ticketRepository.save(any(Ticket.class))).thenReturn(ticket);
+
+        // when
+        Ticket result = ticketCommandService.createTicket(userId, UserRole.USER, seatId);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(ticketRepository).save(any(Ticket.class));
+    }
+
+    @Test
+    void 티켓_생성에_성공하면_남은_좌석_수를_discount_한다() {
+        // given
+        Seat seat = mock(Seat.class);
+        Show show = mock(Show.class);
+        ShowDate showDate = mock(ShowDate.class);
+        User user = mock(User.class);
+
+        when(seatQueryService.findById(seatId)).thenReturn(seat);
+        when(seat.getShowDate()).thenReturn(showDate);
+        when(showDate.getShow()).thenReturn(show);
+        when(show.getReservationStart()).thenReturn(LocalDateTime.now().minusHours(1));
+        when(show.getReservationEnd()).thenReturn(LocalDateTime.now().plusHours(1));
+        when(ticketRepository.existsBySeat(seat)).thenReturn(false);
+        when(userQueryService.findById(userId)).thenReturn(user);
+        when(seat.getPrice()).thenReturn(BigDecimal.valueOf(10000));
+
+        Ticket ticket = mock(Ticket.class);
+        when(ticketRepository.save(any(Ticket.class))).thenReturn(ticket);
+
+        // when
+        ticketCommandService.createTicket(userId, UserRole.USER, seatId);
+
+        // then
+        verify(showDate, times(1)).discountRemainCount();
+    }
+
+    @Test
+    void 이미_예매된_좌석으로_티켓을_생성할_시_예외를_던진다() {
+
+        // given
+        Seat seat = mock(Seat.class);
+        when(seatQueryService.findById(seatId)).thenReturn(seat);
+        when(seat.getShowDate()).thenReturn(mock(ShowDate.class));
+        when(seat.getShowDate().getShow()).thenReturn(mock(Show.class));
+        when(seat.getShowDate().getShow().getReservationStart()).thenReturn(LocalDateTime.now().minusDays(1));
+        when(seat.getShowDate().getShow().getReservationEnd()).thenReturn(LocalDateTime.now().plusDays(1));
+        when(ticketRepository.existsBySeat(seat)).thenReturn(true);
+
+        // when / then
+        assertThatThrownBy(() -> ticketCommandService.createTicket(userId, UserRole.USER, seatId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.SEAT_ALREADY_RESERVED.getMessage());
+    }
+
+    @Test
+    void 예매_시작_시간_이전에_예매할_경우_예외를_던진다() {
+        // given
+        Seat seat = mock(Seat.class);
+        Show show = mock(Show.class);
+        ShowDate showDate = mock(ShowDate.class);
+
+        when(seatQueryService.findById(seatId)).thenReturn(seat);
+        when(seat.getShowDate()).thenReturn(showDate);
+        when(showDate.getShow()).thenReturn(show);
+
+        // 예약 시작 시간 이후가 아님
+        when(show.getReservationStart()).thenReturn(LocalDateTime.now().plusHours(1));
+
+        // when & then
+        assertThatThrownBy(() -> ticketCommandService.createTicket(userId, UserRole.USER, seatId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.SHOW_RESERVATION_TIME_INVALID_BEFORE_SHOW.getMessage());
+    }
+
+    @Test
+    void 예매_종료_시간_이후에_예매할_경우_예외를_던진다() {
+        // given
+        Seat seat = mock(Seat.class);
+        Show show = mock(Show.class);
+        ShowDate showDate = mock(ShowDate.class);
+
+        when(seatQueryService.findById(seatId)).thenReturn(seat);
+        when(seat.getShowDate()).thenReturn(showDate);
+        when(showDate.getShow()).thenReturn(show);
+
+        // 예약 종료 시간 초과
+        when(show.getReservationStart()).thenReturn(LocalDateTime.now().minusHours(3));
+        when(show.getReservationEnd()).thenReturn(LocalDateTime.now().minusHours(1));
+
+        // when / then
+        assertThatThrownBy(() -> ticketCommandService.createTicket(userId, UserRole.USER, seatId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.SHOW_RESERVATION_TIME_INVALID_AFTER_SHOW.getMessage());
+    }
+
+    @Test
+    void 티켓을_삭제할_수_있다() {
+
+        // given
+        Ticket ticket = mock(Ticket.class);
+        Show show = mock(Show.class);
+        ShowDate showDate = mock(ShowDate.class);
+        User user = mock(User.class);
+
+        when(ticket.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(userId);
+        when(ticketRepository.findByTicketId(ticketId)).thenReturn(Optional.of(ticket));
+        when(ticket.getShow()).thenReturn(show);
+        when(showDateQueryService.findByShow(show)).thenReturn(showDate);
+        when(showDate.getDate()).thenReturn(LocalDate.now().plusDays(1));
+
+        // when
+        Ticket result = ticketCommandService.deleteTicket(ticketId, userId);
+
+        // then
+        assertThat(result).isEqualTo(ticket);
+        verify(ticket).updateTicketStatus(TicketStatus.TICKET_CANCELED);
+        verify(ticket).updateTicketStatus(TicketStatus.TICKET_EXPIRED);
+        verify(ticket).updateDeletedAt(any(LocalDateTime.class));
+
+    }
+
+    @Test
+    void 본인이_예매하지_않은_티켓을_삭제할_시_예외를_던진다() {
+        // given
+        Ticket ticket = mock(Ticket.class);
+        User user = mock(User.class);
+
+        when(ticket.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(999L); // 다른 사용자 ID
+        when(ticketRepository.findByTicketId(ticketId)).thenReturn(Optional.of(ticket));
+
+        // when / then
+        assertThatThrownBy(() -> ticketCommandService.deleteTicket(ticketId, userId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.TICKET_CANCEL_FORBIDDEN.getMessage());
+    }
+
+}

--- a/src/test/java/com/example/picket/domain/ticket/service/TicketQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ticket/service/TicketQueryServiceTest.java
@@ -1,0 +1,49 @@
+package com.example.picket.domain.ticket.service;
+
+import com.example.picket.common.dto.AuthUser;
+import com.example.picket.common.enums.Gender;
+import com.example.picket.common.enums.UserRole;
+import com.example.picket.domain.show.entity.Show;
+import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class TicketQueryServiceTest {
+
+    @BeforeEach
+    public void setUp() {
+        User testUser = User.toEntity(
+                "testUser@test.com",
+                "Qwer@1234!",
+                UserRole.USER,
+                "anything",
+                "testUser",
+                LocalDate.of(2002, 2, 2),
+                Gender.FEMALE);
+        User testAdmin = User.toEntity(
+                "testAdmin@test.com",
+                "Qwer@1234!",
+                UserRole.ADMIN,
+                "anything",
+                "testAdmin",
+                LocalDate.of(2002, 2, 2),
+                Gender.FEMALE);
+
+    }
+
+    @Test
+    void getTickets() {
+    }
+
+    @Test
+    void getTicket() {
+    }
+}

--- a/src/test/java/com/example/picket/domain/ticket/service/TicketQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ticket/service/TicketQueryServiceTest.java
@@ -3,47 +3,121 @@ package com.example.picket.domain.ticket.service;
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.UserRole;
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.common.exception.ErrorCode;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.ticket.repository.TicketRepository;
 import com.example.picket.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TicketQueryServiceTest {
 
-    @BeforeEach
-    public void setUp() {
-        User testUser = User.toEntity(
-                "testUser@test.com",
-                "Qwer@1234!",
-                UserRole.USER,
-                "anything",
-                "testUser",
-                LocalDate.of(2002, 2, 2),
-                Gender.FEMALE);
-        User testAdmin = User.toEntity(
-                "testAdmin@test.com",
-                "Qwer@1234!",
-                UserRole.ADMIN,
-                "anything",
-                "testAdmin",
-                LocalDate.of(2002, 2, 2),
-                Gender.FEMALE);
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @InjectMocks
+    private TicketQueryService ticketQueryService;
+
+    @Test
+    void 티켓을_다건_조회할_수_있다() {
+
+        // given
+        Long userId = 1L;
+        int size = 10;
+        int page = 1;
+
+        Ticket ticket = mock(Ticket.class);
+        Page<Ticket> ticketPage = new PageImpl<>(List.of(ticket));
+
+        when(ticketRepository.findByUser(eq(userId), any(Pageable.class)))
+                .thenReturn(ticketPage);
+
+        // when
+        Page<Ticket> result = ticketQueryService.getTickets(userId, size, page);
+
+        // then
+        assertThat(result.getContent()).contains(ticket);
+        verify(ticketRepository).findByUser(eq(userId), any(Pageable.class));
 
     }
 
     @Test
-    void getTickets() {
+    void 티켓을_단건_조회할_수_있다() {
+
+        // given
+        Long userId = 1L;
+        Long ticketId = 10L;
+
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn(userId);
+
+        Ticket ticket = mock(Ticket.class);
+        when(ticket.getUser()).thenReturn(mockUser);
+
+        when(ticketRepository.findByTicketId(ticketId)).thenReturn(Optional.of(ticket));
+
+        // when
+        Ticket result = ticketQueryService.getTicket(userId, ticketId);
+
+        // then
+        assertThat(result).isEqualTo(ticket);
+
     }
 
     @Test
-    void getTicket() {
+    void 존재하지_않는_티켓을_조회_시_예외를_던진다() {
+        // given
+        Long userId = 1L;
+        Long ticketId = 999L;
+
+        when(ticketRepository.findByTicketId(ticketId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ticketQueryService.getTicket(userId, ticketId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.TICKET_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 본인이_예매하지_않은_티켓을_조회_시_예외를_던진다() {
+
+        // given
+        Long userId = 1L;
+        Long ticketId = 123L;
+
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn(999L); // 다른 유저
+
+        Ticket ticket = mock(Ticket.class);
+        when(ticket.getUser()).thenReturn(mockUser);
+
+        when(ticketRepository.findByTicketId(ticketId)).thenReturn(Optional.of(ticket));
+
+        // when & then
+        assertThatThrownBy(() -> ticketQueryService.getTicket(userId, ticketId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.TICKET_ACCESS_DENIED.getMessage());
+
     }
 }

--- a/src/test/java/com/example/picket/domain/ticket/service/TicketQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ticket/service/TicketQueryServiceTest.java
@@ -1,15 +1,10 @@
 package com.example.picket.domain.ticket.service;
 
-import com.example.picket.common.dto.AuthUser;
-import com.example.picket.common.enums.Gender;
-import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.common.exception.ErrorCode;
-import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.ticket.repository.TicketRepository;
 import com.example.picket.domain.user.entity.User;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,13 +14,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
📌 반영 브랜치
feat/ticket -> dev

✅ 작업 내용
티켓 생성, 조회, 삭제에 대한 Service 단위 테스트 코드 작성
예외 상황 검증 로직 포함
티켓 생성 시 N+1 문제 해결
yml에서 sql 로그 보이도록 추가

🎯 단독 테스트 결과
로컬 테스트 기준 단위 테스트 통과

🚨 연관 이슈
closes #47