### PR TITLE
Swagger 설정 추가 및 댓글 API 문서화 어노테이션 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/picket/common/annotation/Auth.java
+++ b/src/main/java/com/example/picket/common/annotation/Auth.java
@@ -1,5 +1,7 @@
 package com.example.picket.common.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,5 +9,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface Auth {
 }

--- a/src/main/java/com/example/picket/common/annotation/AuthPermission.java
+++ b/src/main/java/com/example/picket/common/annotation/AuthPermission.java
@@ -1,12 +1,14 @@
 package com.example.picket.common.annotation;
 
 import com.example.picket.common.enums.UserRole;
+import io.swagger.v3.oas.annotations.Parameter;
 
 import java.lang.annotation.*;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Parameter(hidden = true)
 public @interface AuthPermission {
     UserRole role();
 }

--- a/src/main/java/com/example/picket/common/consts/Const.java
+++ b/src/main/java/com/example/picket/common/consts/Const.java
@@ -9,11 +9,15 @@ public interface Const {
     //TODO : 추후 로그인 없이도 방문가능한 페이지의 경우 해당 화이트 리스트에 URL 추가
     Map<String, String[]> WHITE_LIST = Map.of(
             "GET", new String[]{
-                    "/api/v1/shows/*/comments"
+                    "/api/v1/shows/*/comments",
+                    "/swagger-ui/*",
+                    "/v3/api-docs/**"
             },
             "POST", new String[]{
                     "/api/v1/auth/signup/*",
                     "/api/v1/auth/signin",
+                    "/swagger-ui/*",
+                    "/v3/api-docs/**"
             },
             "PUT", new String[]{
 

--- a/src/main/java/com/example/picket/config/SwaggerConfig.java
+++ b/src/main/java/com/example/picket/config/SwaggerConfig.java
@@ -1,0 +1,60 @@
+package com.example.picket.config;
+
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
+
+@SecurityScheme(
+        type = SecuritySchemeType.APIKEY,
+        name = "SESSIONID",
+        description = "세션 ID 쿠키를 입력해주세요.",
+        in = SecuritySchemeIn.COOKIE
+)
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI api() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("SESSIONID",
+                                new io.swagger.v3.oas.models.security.SecurityScheme()
+                                        .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.APIKEY)
+                                        .in(io.swagger.v3.oas.models.security.SecurityScheme.In.COOKIE)
+                                        .name("SESSIONID")
+                                        .description("세션 ID를 쿠키에 입력해주세요.")
+                        )
+                )
+                .info(apiInfo())
+                .security(Collections.singletonList(new SecurityRequirement().addList("SESSIONID")));
+    }
+
+    @Bean
+    public GroupedOpenApi groupedOpenApi() {
+        String[] packages = {"com.example.picket"};
+        return GroupedOpenApi.builder()
+                .group("springdoc-openapi")
+                .packagesToScan(packages)
+                .build();
+    }
+
+    private Info apiInfo() {
+        String description = "티켓팅 플랫폼을 구현해보는 프로젝트입니다.";
+        return new Info()
+                .title("Ticket을 Pick 하다.")
+                .description(description);
+    }
+}

--- a/src/main/java/com/example/picket/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/picket/domain/comment/controller/CommentController.java
@@ -9,7 +9,10 @@ import com.example.picket.domain.comment.entity.Comment;
 import com.example.picket.domain.comment.service.CommentCommandService;
 import com.example.picket.domain.comment.service.CommentQueryService;
 import com.example.picket.domain.ticket.service.TicketQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -21,12 +24,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/")
+@Tag(name = "댓글 관리 API", description = "댓글 다건조회, 생성, 수정, 삭제 기능 API입니다.")
 public class CommentController {
 
     private final CommentCommandService commentCommandService;
     private final CommentQueryService  commentQueryService;
     private final TicketQueryService ticketQueryService;
 
+    @Operation(summary = "댓글 생성", description = "댓글을 생성할 수 있습니다.")
     @PostMapping("/shows/{showId}/comments")
     public ResponseEntity<CommentResponse> createComment(@Auth AuthUser auth,
                                                          @PathVariable Long showId,
@@ -40,6 +45,7 @@ public class CommentController {
         return ResponseEntity.ok(CommentResponse.toDto(comment, hasTicket));
     }
 
+    @Operation(summary = "댓글 수정", description = "댓글을 수정할 수 있습니다.")
     @PatchMapping("/shows/{showId}/comments/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(@Auth AuthUser auth,
                                                          @PathVariable Long showId,
@@ -54,14 +60,17 @@ public class CommentController {
         return ResponseEntity.ok(CommentResponse.toDto(comment, hasTicket));
     }
 
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제할 수 있습니다.")
     @DeleteMapping("/shows/{showId}/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(@Auth AuthUser auth, @PathVariable Long showId, @PathVariable Long commentId) {
         commentCommandService.deleteComment(auth.getId(), showId, commentId);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "댓글 다건 조회", description = "댓글을 다건 조회할 수 있습니다.")
     @GetMapping("/shows/{showId}/comments")
-    public ResponseEntity<PageCommentResponse> getComments(@PathVariable Long showId, @PageableDefault(size = 10, page = 0) Pageable pageable) {
+    public ResponseEntity<PageCommentResponse> getComments(@PathVariable Long showId
+            , @ParameterObject @PageableDefault(size = 10, page = 0, sort = "createdAt,desc") Pageable pageable) {
         Page<Comment> comments = commentQueryService.getComments(showId, pageable);
 
         List<Long> userIds = comments.getContent().stream()

--- a/src/main/java/com/example/picket/domain/comment/dto/request/CommentRequest.java
+++ b/src/main/java/com/example/picket/domain/comment/dto/request/CommentRequest.java
@@ -1,5 +1,6 @@
 package com.example.picket.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CommentRequest {
 
+    @Schema(description = "댓글 내용", example = "공연에대한 댓글입니다.")
     @NotBlank
     private String content;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,11 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
+
+springdoc:
+  override-with-generic-response: false
+
+  spring:
+    session:
+      cookie:
+        same-site: lax


### PR DESCRIPTION
### 📌 반영 브랜치
feat/comment -> dev

### ✅ 작업 내용
- Swagger(SpringDoc) 기반 API 문서화 환경 구축
- 댓글 API 문서 처리

- #### 📄 주요 작업
- Swagger 설정 클래스(`SwaggerConfig`) 추가
- Swagger 문서에서 `@Auth` 파라미터가 requestBody에 포함되지 않도록 `@Parameter(hidden = true)` 처리
- 댓글(Comment) API 문서화
  - 컨트롤러에 `@Tag`, 각 메서드에 `@Operation` 어노테이션 추가
  - 요청 DTO에 `@Schema`를 통한 필드 설명 및 예시값 부여

### 🎯 단독 테스트 결과
- Swagger UI (http://localhost:8080/swagger-ui/index.html) 접속 확인
- 댓글 API 요청/응답 예시 정상 출력
- 세션 인증 쿠키(SESSIONID) 입력 후 API 테스트 성공
- `@Auth` 파라미터가 Swagger 문서에 포함되지 않는 것 확인

### 🎯 단독 테스트 결과

### 🚨 연관 이슈
closes #61 