### PR TITLE
인증/인가 추가 구현 및 좋아요, 티켓 부분 PageResponse 통일 수정

### DIFF
--- a/src/main/java/com/example/picket/common/auth/AuthUserArgumentResolver.java
+++ b/src/main/java/com/example/picket/common/auth/AuthUserArgumentResolver.java
@@ -1,6 +1,7 @@
 package com.example.picket.common.auth;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.dto.AuthUser;
@@ -38,9 +39,18 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             WebDataBinderFactory binderFactory
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        HttpSession session = request.getSession();
+        HttpSession session = request.getSession(false);
 
-        return session == null ? false : (AuthUser) session.getAttribute("authUser");
+        if (session == null) {
+            throw new CustomException(UNAUTHORIZED, "세션이 유효하지 않습니다.");
+        }
+
+        AuthUser authUser = (AuthUser) session.getAttribute("authUser");
+        if (authUser == null) {
+            throw new CustomException(UNAUTHORIZED, "인증 정보가 없습니다.");
+        }
+
+        return authUser;
     }
 
 }

--- a/src/main/java/com/example/picket/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/example/picket/common/interceptor/AuthInterceptor.java
@@ -25,7 +25,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        if (session == null) {
+        if (session == null || session.getAttribute("authUser") == null) {
             throw new CustomException(UNAUTHORIZED, "로그인 이후 이용 가능합니다.");
         }
 

--- a/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.example.picket.domain.auth.service.AuthService;
 import com.example.picket.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -52,16 +53,17 @@ public class AuthController {
 
     @Operation(summary = "로그인", description = "로그인을 할 수 있습니다.")
     @PostMapping("/auth/signin")
-    public ResponseEntity<SigninResponse> signin(HttpSession session, @Valid @RequestBody SigninRequest request) {
-        User user = authService.signin(session, request.getEmail(), request.getPassword());
-        SigninResponse response = SigninResponse.toDto(user.getNickname());
-        return ResponseEntity.ok(response);
+    public ResponseEntity<SigninResponse> signin(HttpSession session, HttpServletResponse response,
+                                                 @Valid @RequestBody SigninRequest request) {
+        User user = authService.signin(session, response, request.getEmail(), request.getPassword());
+        SigninResponse signinResponse = SigninResponse.toDto(user.getNickname());
+        return ResponseEntity.ok(signinResponse);
     }
 
     @Operation(summary = "로그아웃", description = "로그인 되어있는 상태의 경우, 로그아웃을 할 수 있습니다.")
     @PostMapping("/auth/signout")
-    public ResponseEntity<Void> signout(HttpSession session) {
-        authService.signout(session);
+    public ResponseEntity<Void> signout(HttpSession session, HttpServletResponse response) {
+        authService.signout(session, response);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/picket/domain/like/controller/LikeController.java
@@ -2,6 +2,7 @@ package com.example.picket.domain.like.controller;
 
 import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.dto.AuthUser;
+import com.example.picket.common.dto.PageResponse;
 import com.example.picket.domain.like.dto.response.LikeResponse;
 import com.example.picket.domain.like.service.LikeCommandService;
 import com.example.picket.domain.like.service.LikeQueryService;
@@ -35,9 +36,9 @@ public class LikeController {
 
     @Operation(summary = "좋아요한 공연 목록 조회", description = "사용자가 좋아요한 공연 목록조회를 할 수 있습니다.")
     @GetMapping("/likes")
-    public ResponseEntity<Page<LikeResponse>> getLikes(@RequestParam(defaultValue = "0") int page,
-                                                       @RequestParam(defaultValue = "10") int size,
-                                                       @Auth AuthUser authUser) {
+    public ResponseEntity<PageResponse<LikeResponse>> getLikes(@RequestParam(defaultValue = "0") int page,
+                                                               @RequestParam(defaultValue = "10") int size,
+                                                               @Auth AuthUser authUser) {
         List<Show> shows = likeQueryService.getLikes(authUser.getId(), page, size);
         Pageable pageable = PageRequest.of(page, size);
         List<LikeResponse> likeResponses = shows.stream().map(
@@ -49,7 +50,7 @@ public class LikeController {
                 )
         ).toList();
         Page<LikeResponse> responses = new PageImpl<>(likeResponses, pageable, likeResponses.size());
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(PageResponse.toDto(responses));
     }
 
     @Operation(summary = "좋아요 추가", description = "특정 공연에 좋아요를 추가할 수 있습니다.")

--- a/src/main/java/com/example/picket/domain/show/dto/request/ShowCreateRequest.java
+++ b/src/main/java/com/example/picket/domain/show/dto/request/ShowCreateRequest.java
@@ -1,7 +1,6 @@
 package com.example.picket.domain.show.dto.request;
 
 import com.example.picket.common.enums.Category;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
@@ -36,11 +35,11 @@ public class ShowCreateRequest {
     @NotBlank(message = "공연 장소는 필수 입력 값입니다.")
     private String location;
 
-    @Schema(description = "예매 시작일 (형식: yyyy-MM-dd'T'HH:mm:ss)", example = "2025-05-01T00:00:00")
+    @Schema(description = "예매 시작일 (형식: yyyy-MM-dd'T'HH:mm:ss)", example = "2025-05-01T00:00:00.000Z")
     @NotNull(message = "예매 시작일은 필수 입력 값입니다.")
     private LocalDateTime reservationStart;
 
-    @Schema(description = "예매 종료일 (형식: yyyy-MM-dd'T'HH:mm:ss, null이면 공연시작 전날 자정으로 설정)", example = "2025-05-10T00:00:00")
+    @Schema(description = "예매 종료일 (형식: yyyy-MM-dd'T'HH:mm:ss, null이면 공연시작 전날 자정으로 설정)", example = "2025-05-10T00:00:00.000Z")
     private LocalDateTime reservationEnd;
 
     @Schema(description = "인당 최대 구매 가능 티켓수", example = "2")

--- a/src/main/java/com/example/picket/domain/show/dto/request/ShowUpdateRequest.java
+++ b/src/main/java/com/example/picket/domain/show/dto/request/ShowUpdateRequest.java
@@ -1,12 +1,10 @@
 package com.example.picket.domain.show.dto.request;
 
 import com.example.picket.common.enums.Category;
-import java.time.LocalDateTime;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -34,11 +32,11 @@ public class ShowUpdateRequest {
     @NotBlank(message = "공연 장소는 필수 입력 값입니다.")
     private String location;
 
-    @Schema(description = "예매 시작일 (형식: yyyy-MM-dd'T'HH:mm:ss)", example = "2025-05-02T00:00:00")
+    @Schema(description = "예매 시작일 (형식: yyyy-MM-dd'T'HH:mm:ss)", example = "2025-04-09T00:00:00.000Z")
     @NotNull(message = "예매 시작일은 필수 입력 값입니다.")
     private LocalDateTime reservationStart;
 
-    @Schema(description = "예매 종료일 (형식: yyyy-MM-dd'T'HH:mm:ss, null이면 공연시작 전날 자정으로 설정)", example = "2025-05-09T00:00:00")
+    @Schema(description = "예매 종료일 (형식: yyyy-MM-dd'T'HH:mm:ss, null이면 공연시작 전날 자정으로 설정)", example = "2025-05-09T00:00:00.000Z")
     private LocalDateTime reservationEnd;
 
     @Schema(description = "인당 최대 구매 가능 티켓수", example = "100")

--- a/src/main/java/com/example/picket/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/example/picket/domain/ticket/controller/TicketController.java
@@ -3,6 +3,7 @@ package com.example.picket.domain.ticket.controller;
 import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.annotation.AuthPermission;
 import com.example.picket.common.dto.AuthUser;
+import com.example.picket.common.dto.PageResponse;
 import com.example.picket.common.enums.UserRole;
 import com.example.picket.domain.ticket.dto.response.CreateTicketResponse;
 import com.example.picket.domain.ticket.dto.response.DeleteTicketResponse;
@@ -44,14 +45,14 @@ public class TicketController {
 
     @Operation(summary = "티켓 다건 조회", description = "티켓을 다건 조회할 수 있습니다.")
     @GetMapping("tickets")
-    public ResponseEntity<Page<GetTicketResponse>> getTickets(
+    public ResponseEntity<PageResponse<GetTicketResponse>> getTickets(
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "1") int page,
             @Auth AuthUser authUser
     ) {
         Page<GetTicketResponse> getTicketResponsePage = ticketQueryService.getTickets(authUser.getId(), size, page)
                 .map(GetTicketResponse::toDto);
-        return ResponseEntity.ok(getTicketResponsePage);
+        return ResponseEntity.ok(PageResponse.toDto(getTicketResponsePage));
     }
 
     @Operation(summary = "티켓 단건 조회", description = "티켓을 단건 조회할 수 있습니다.")


### PR DESCRIPTION
### 📌 반영 브랜치
feat/auth -> dev

### ✅ 작업 내용
- Auth : set-cookie 추가하여 response header에서 쿠키 확인할 수 있도록 함
- Like, Ticket 부분에 PageResponse를 사용한 목록 조회로 수정
- Interceptor 및 ArgumentResolver에서 session 및 authUser 존재하는지 검사할 수 있도록 추가

### 🎯 기대 결과 (Expected Result)
- PageResponse로 통일
- set-cookie 통하여 response header에서 쿠키 확인 가능

### 🚨 연관 이슈
closes #81 

