### PR TITLE
chore: springdoc 2.8.6 업그레이드에 따른 불필요 설정 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/picket/domain/show/dto/request/ShowCreateRequest.java
+++ b/src/main/java/com/example/picket/domain/show/dto/request/ShowCreateRequest.java
@@ -35,11 +35,11 @@ public class ShowCreateRequest {
     @NotBlank(message = "공연 장소는 필수 입력 값입니다.")
     private String location;
 
-    @Schema(description = "예매 시작일 (형식: yyyy-MM-dd'T'HH:mm:ss)", example = "2025-05-01T00:00:00.000Z")
+    @Schema(description = "예매 시작일 (형식: yyyy-MM-dd'T'HH:mm:ss)", example = "2025-05-01T00:00:00")
     @NotNull(message = "예매 시작일은 필수 입력 값입니다.")
     private LocalDateTime reservationStart;
 
-    @Schema(description = "예매 종료일 (형식: yyyy-MM-dd'T'HH:mm:ss, null이면 공연시작 전날 자정으로 설정)", example = "2025-05-10T00:00:00.000Z")
+    @Schema(description = "예매 종료일 (형식: yyyy-MM-dd'T'HH:mm:ss, null이면 공연시작 전날 자정으로 설정)", example = "2025-05-10T00:00:00")
     private LocalDateTime reservationEnd;
 
     @Schema(description = "인당 최대 구매 가능 티켓수", example = "2")

--- a/src/main/java/com/example/picket/domain/show/dto/request/ShowUpdateRequest.java
+++ b/src/main/java/com/example/picket/domain/show/dto/request/ShowUpdateRequest.java
@@ -32,11 +32,11 @@ public class ShowUpdateRequest {
     @NotBlank(message = "공연 장소는 필수 입력 값입니다.")
     private String location;
 
-    @Schema(description = "예매 시작일 (형식: yyyy-MM-dd'T'HH:mm:ss)", example = "2025-04-09T00:00:00.000Z")
+    @Schema(description = "예매 시작일 (형식: yyyy-MM-dd'T'HH:mm:ss)", example = "2025-04-09T00:00:00")
     @NotNull(message = "예매 시작일은 필수 입력 값입니다.")
     private LocalDateTime reservationStart;
 
-    @Schema(description = "예매 종료일 (형식: yyyy-MM-dd'T'HH:mm:ss, null이면 공연시작 전날 자정으로 설정)", example = "2025-05-09T00:00:00.000Z")
+    @Schema(description = "예매 종료일 (형식: yyyy-MM-dd'T'HH:mm:ss, null이면 공연시작 전날 자정으로 설정)", example = "2025-05-09T00:00:00")
     private LocalDateTime reservationEnd;
 
     @Schema(description = "인당 최대 구매 가능 티켓수", example = "100")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,17 +10,9 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
-
-springdoc:
-  override-with-generic-response: false
-
-  spring:
-    session:
-      cookie:
-        same-site: lax


### PR DESCRIPTION
### 📌 반영 브랜치
feat/comment -> dev

### ✅ 작업 내용 
- springdoc-openapi 버전 2.8.6으로 업그레이드
- 더 이상 사용되지 않는 설정(override-with-generic-response, same-site 등) 제거
- 관련 설정 주석 처리했던 코드 제거하여 설정 파일 정리

### 🎯 단독 테스트 결과
