### PR TITLE
예매, 예매취소, 주문 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // shedlock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.2.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/picket/common/enums/OrderStatus.java
+++ b/src/main/java/com/example/picket/common/enums/OrderStatus.java
@@ -1,0 +1,25 @@
+package com.example.picket.common.enums;
+
+import com.example.picket.common.exception.CustomException;
+
+import java.util.Arrays;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public enum OrderStatus {
+    ORDER_PENDING("결제 대기"),
+    ORDER_COMPLETE("주문 완료");
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+
+    public static OrderStatus of(String type) {
+        return Arrays.stream(OrderStatus.values())
+                .filter(t -> t.name().equalsIgnoreCase(type))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(BAD_REQUEST, "유효하지 않은 주문 유형입니다."));
+    }
+}

--- a/src/main/java/com/example/picket/common/scheduler/SeatStatusScheduler.java
+++ b/src/main/java/com/example/picket/common/scheduler/SeatStatusScheduler.java
@@ -1,0 +1,52 @@
+package com.example.picket.common.scheduler;
+
+import com.example.picket.common.enums.SeatStatus;
+import com.example.picket.domain.seat.entity.Seat;
+import com.example.picket.domain.seat.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SeatStatusScheduler {
+    private final SeatRepository seatRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    @Scheduled(fixedDelay = 300000) // 5분마다 실행
+    @SchedulerLock(name = "SEATSTATUS-SCHEDULER",
+            lockAtLeastFor = "PT1M", lockAtMostFor = "PT5M")
+    public void cleanUpOccupiedSeats() {
+
+        log.info("[SEAT CLEANUP] 예약된 좌석 상태 정리 작업 시작");
+
+        List<Seat> occupiedSeats = seatRepository.findAllBySeatStatus(SeatStatus.OCCUPIED);
+
+        log.info("[SEAT CLEANUP] 점유된 좌석 수: {}", occupiedSeats.size());
+
+        List<Seat> updatedSeats = new ArrayList<>();
+
+        for (Seat seat : occupiedSeats) {
+            String redisSeatKey = "SEAT-HOLDING-LOCK:SEAT:" + seat.getId();
+
+            Boolean exists = redisTemplate.hasKey(redisSeatKey);
+            if (exists == null || !exists) {
+                seat.updateSeatStatus(SeatStatus.AVAILABLE);
+                updatedSeats.add(seat);
+                log.info("[SEAT CLEANUP] Redis 키 없음 → 좌석 상태 AVAILABLE로 변경 (seatId: {})", seat.getId());
+            }
+        }
+
+        seatRepository.saveAll(updatedSeats);
+
+        log.info("[SEAT CLEANUP] 상태 변경된 좌석 수: {}", updatedSeats.size());
+        log.info("[SEAT CLEANUP] 예약된 좌석 상태 정리 작업 종료");
+    }
+}

--- a/src/main/java/com/example/picket/config/SchedulerConfig.java
+++ b/src/main/java/com/example/picket/config/SchedulerConfig.java
@@ -1,0 +1,20 @@
+package com.example.picket.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT5M")
+public class SchedulerConfig {
+    @Bean
+    public RedisLockProvider lockProvider(RedisConnectionFactory redisConnectionFactory) {
+        return new RedisLockProvider(redisConnectionFactory);
+    }
+}

--- a/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
@@ -50,7 +50,8 @@ public class BookingController {
             @RequestBody CancelBookingRequest dto
     ) throws InterruptedException {
         List<Ticket> canceledTickets = bookingService.cancelBooking(showId, showDateId, authUser.getId(), dto.getTicketIds());
-        CancelBookingResponse cancelBookingResponse = CancelBookingResponse.toDto(canceledTickets);
+        List<GetTicketResponse> getTicketResponses = canceledTickets.stream().map(GetTicketResponse::toDto).toList();
+        CancelBookingResponse cancelBookingResponse = CancelBookingResponse.toDto(getTicketResponses);
         return ResponseEntity.ok(cancelBookingResponse);
     }
 }

--- a/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
@@ -3,18 +3,22 @@ package com.example.picket.domain.booking.controller;
 import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.domain.booking.dto.request.BookingRequest;
+import com.example.picket.domain.booking.dto.request.CancelBookingRequest;
+import com.example.picket.domain.booking.dto.response.CancelBookingResponse;
 import com.example.picket.domain.booking.service.BookingService;
 import com.example.picket.domain.order.dto.response.OrderResponse;
 import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
+import com.example.picket.domain.ticket.entity.Ticket;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 @Controller
 @RequestMapping("/api/v2/")
@@ -35,5 +39,18 @@ public class BookingController {
         Order order = bookingService.booking(showId, showDateId, authUser.getId(), dto.getSeatIds());
         OrderResponse orderResponse = OrderResponse.toDto(order);
         return ResponseEntity.ok(orderResponse);
+    }
+
+    @Operation(summary = "예매취소", description = "예매된 티켓을 취소할 수 있습니다.")
+    @DeleteMapping("show/{showId}/show-date/{showDateId}/booking")
+    public ResponseEntity<CancelBookingResponse> cancelBooking(
+            @PathVariable Long showId,
+            @PathVariable Long showDateId,
+            @Auth AuthUser authUser,
+            @RequestBody CancelBookingRequest dto
+    ) throws InterruptedException {
+        List<Ticket> canceledTickets = bookingService.cancelBooking(showId, showDateId, authUser.getId(), dto.getTicketIds());
+        CancelBookingResponse cancelBookingResponse = CancelBookingResponse.toDto(canceledTickets);
+        return ResponseEntity.ok(cancelBookingResponse);
     }
 }

--- a/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
@@ -24,7 +24,6 @@ public class BookingController {
 
     private final BookingService bookingService;
 
-    // 예매 API
     @Operation(summary = "예매", description = "좌석을 예매하여 티켓, 주문을 생성할 수 있습니다.")
     @PostMapping("show/{showId}/show-date/{showDateId}/booking")
     public ResponseEntity<OrderResponse> booking(

--- a/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
@@ -6,6 +6,8 @@ import com.example.picket.domain.booking.dto.request.BookingRequest;
 import com.example.picket.domain.booking.service.BookingService;
 import com.example.picket.domain.order.dto.response.OrderResponse;
 import com.example.picket.domain.order.entity.Order;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -17,11 +19,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping("/api/v2/")
 @RequiredArgsConstructor
+@Tag(name = "예매 API", description = "예매, 예매취소 기능 API입니다.")
 public class BookingController {
 
     private final BookingService bookingService;
 
     // 예매 API
+    @Operation(summary = "예매", description = "좌석을 예매하여 티켓, 주문을 생성할 수 있습니다.")
     @PostMapping("show/{showId}/show-date/{showDateId}/booking")
     public ResponseEntity<OrderResponse> booking(
             @PathVariable Long showId,

--- a/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
@@ -1,0 +1,36 @@
+package com.example.picket.domain.booking.controller;
+
+import com.example.picket.common.annotation.Auth;
+import com.example.picket.common.dto.AuthUser;
+import com.example.picket.domain.booking.dto.request.BookingRequest;
+import com.example.picket.domain.booking.service.BookingService;
+import com.example.picket.domain.order.dto.response.OrderResponse;
+import com.example.picket.domain.order.entity.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v2/")
+@RequiredArgsConstructor
+public class BookingController {
+
+    private final BookingService bookingService;
+
+    // 예매 API
+    @PostMapping("show/{showId}/show-date/{showDateId}/booking")
+    public ResponseEntity<OrderResponse> booking(
+            @PathVariable Long showId,
+            @PathVariable Long showDateId,
+            @Auth AuthUser authUser,
+            @RequestBody BookingRequest dto
+            ) throws InterruptedException {
+        Order order = bookingService.booking(showId, showDateId, authUser.getId(), dto.getSeatIds());
+        OrderResponse orderResponse = OrderResponse.toDto(order);
+        return ResponseEntity.ok(orderResponse);
+    }
+}

--- a/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
@@ -12,5 +12,5 @@ public class BookingRequest {
 
     @Schema(description = "예매할 좌석 ID", example = "[1]")
     @NotNull(message = "좌석 ID는 필수 입력값입니다.")
-    private List<Long> seatIds = new ArrayList<>();
+    private final List<Long> seatIds = new ArrayList<>();
 }

--- a/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
@@ -1,0 +1,16 @@
+package com.example.picket.domain.booking.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class BookingRequest {
+
+    @Schema(description = "예매할 좌석 ID", example = "[1]")
+    @NotNull(message = "좌석 ID는 필수 입력값입니다.")
+    private List<Long> seatIds = new ArrayList<>();
+}

--- a/src/main/java/com/example/picket/domain/booking/dto/request/CancelBookingRequest.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/request/CancelBookingRequest.java
@@ -1,0 +1,16 @@
+package com.example.picket.domain.booking.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CancelBookingRequest {
+
+    @Schema(description = "취소할 티켓 ID", example = "[1]")
+    @NotNull(message = "티켓 ID는 필수 입력값입니다.")
+    private List<Long> ticketIds = new ArrayList<>();
+}

--- a/src/main/java/com/example/picket/domain/booking/dto/request/CancelBookingRequest.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/request/CancelBookingRequest.java
@@ -12,5 +12,5 @@ public class CancelBookingRequest {
 
     @Schema(description = "취소할 티켓 ID", example = "[1]")
     @NotNull(message = "티켓 ID는 필수 입력값입니다.")
-    private List<Long> ticketIds = new ArrayList<>();
+    private final List<Long> ticketIds = new ArrayList<>();
 }

--- a/src/main/java/com/example/picket/domain/booking/dto/response/CancelBookingResponse.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/response/CancelBookingResponse.java
@@ -1,0 +1,22 @@
+package com.example.picket.domain.booking.dto.response;
+
+import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
+import com.example.picket.domain.ticket.entity.Ticket;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CancelBookingResponse {
+
+    private List<Ticket> cancelledTickets;
+
+    private CancelBookingResponse(List<Ticket> cancelledTickets) {
+        this.cancelledTickets = cancelledTickets;
+    }
+
+    public static CancelBookingResponse toDto(List<Ticket> cancelledTickets) {
+        return new CancelBookingResponse(cancelledTickets);
+    }
+}

--- a/src/main/java/com/example/picket/domain/booking/dto/response/CancelBookingResponse.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/response/CancelBookingResponse.java
@@ -10,13 +10,13 @@ import java.util.List;
 @Getter
 public class CancelBookingResponse {
 
-    private List<Ticket> cancelledTickets;
+    private final List<GetTicketResponse> cancelledTickets;
 
-    private CancelBookingResponse(List<Ticket> cancelledTickets) {
+    private CancelBookingResponse(List<GetTicketResponse> cancelledTickets) {
         this.cancelledTickets = cancelledTickets;
     }
 
-    public static CancelBookingResponse toDto(List<Ticket> cancelledTickets) {
+    public static CancelBookingResponse toDto(List<GetTicketResponse> cancelledTickets) {
         return new CancelBookingResponse(cancelledTickets);
     }
 }

--- a/src/main/java/com/example/picket/domain/booking/service/BookingService.java
+++ b/src/main/java/com/example/picket/domain/booking/service/BookingService.java
@@ -1,6 +1,5 @@
 package com.example.picket.domain.booking.service;
 
-import com.example.picket.common.enums.SeatStatus;
 import com.example.picket.common.enums.TicketStatus;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.order.entity.Order;
@@ -17,15 +16,12 @@ import com.example.picket.domain.ticket.service.TicketCommandService;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
-import org.redisson.api.RBucket;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -95,8 +91,7 @@ public class BookingService {
         return seatIds.stream()
                 .map(seatId -> {
                     Seat seat = seatQueryService.getSeat(seatId);
-                    seat.updateSeatStatus(SeatStatus.RESERVED);
-                    return ticketCommandService.createTicketVer2(user, show, seat, TicketStatus.TICKET_CREATED);
+                    return ticketCommandService.createTicket(user, show, seat, TicketStatus.TICKET_CREATED);
                 })
                 .toList();
     }

--- a/src/main/java/com/example/picket/domain/booking/service/BookingService.java
+++ b/src/main/java/com/example/picket/domain/booking/service/BookingService.java
@@ -1,0 +1,99 @@
+package com.example.picket.domain.booking.service;
+
+import com.example.picket.common.enums.SeatStatus;
+import com.example.picket.common.enums.TicketStatus;
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.order.service.OrderCommandService;
+import com.example.picket.domain.seat.entity.Seat;
+import com.example.picket.domain.seat.service.SeatQueryService;
+import com.example.picket.domain.seat_holding.service.SeatHoldingService;
+import com.example.picket.domain.show.entity.Show;
+import com.example.picket.domain.show.entity.ShowDate;
+import com.example.picket.domain.show.service.ShowDateQueryService;
+import com.example.picket.domain.show.service.ShowQueryService;
+import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.ticket.service.TicketCommandService;
+import com.example.picket.domain.user.entity.User;
+import com.example.picket.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Service
+@RequiredArgsConstructor
+public class BookingService {
+
+    private final RedissonClient redissonClient;
+    private final String KEY_PREFIX = "UPDATE-COUNT-LOCK:SHOW-DATE:";
+
+    private final SeatHoldingService seatHoldingService;
+
+    private final SeatQueryService seatQueryService;
+    private final ShowQueryService showQueryService;
+    private final UserQueryService userQueryService;
+    private final ShowDateQueryService showDateQueryService;
+
+    private final OrderCommandService orderCommandService;
+    private final TicketCommandService ticketCommandService;
+
+
+    public Order booking(Long showId, Long showDateId, Long userId, List<Long> seatIds) throws InterruptedException {
+
+        Show foundShow = showQueryService.getShow(showId);
+        checkBookingTime(foundShow);
+
+        seatHoldingService.seatHoldingCheck(userId, seatIds);
+
+        User foundUser = userQueryService.getUser(userId);
+        ShowDate foundShowDate = showDateQueryService.getShowDate(showDateId);
+
+        List<Ticket> tickets = new ArrayList<>();
+
+        for (Long seatId : seatIds) {
+            Seat foundSeat = seatQueryService.getSeat(seatId);
+            Ticket ticket = ticketCommandService.createTicketVer2(foundUser, foundShow, foundSeat, TicketStatus.TICKET_CREATED);
+            tickets.add(ticket);
+        }
+
+        Order order = orderCommandService.createOrder(foundUser, tickets);
+
+        String lockKey = KEY_PREFIX + showDateId;
+        RLock lock = redissonClient.getFairLock(lockKey);
+
+
+        if (lock.tryLock(10, TimeUnit.SECONDS)) {
+            try {
+                foundShowDate.updateCountOnBooking(seatIds.size());
+            } finally {
+                lock.unlock();
+            }
+        } else {
+            throw new IllegalStateException("락 획득 실패: " + lockKey);
+        }
+
+        return order;
+    }
+
+    private void checkBookingTime(Show show) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(show.getReservationStart())) {
+            throw new CustomException(BAD_REQUEST, "예매 시작 시간 전입니다.");
+        }
+
+        if (now.isAfter(show.getReservationEnd())) {
+            throw new CustomException(BAD_REQUEST, "예매 종료 시간 이후 입니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/picket/domain/booking/service/BookingService.java
+++ b/src/main/java/com/example/picket/domain/booking/service/BookingService.java
@@ -1,5 +1,6 @@
 package com.example.picket.domain.booking.service;
 
+import com.example.picket.common.enums.OrderStatus;
 import com.example.picket.common.enums.TicketStatus;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.order.entity.Order;
@@ -64,6 +65,10 @@ public class BookingService {
 
         Order order = orderCommandService.createOrder(foundUser, tickets);
 
+        // TODO : 사이에 결제 로직
+
+        order.updateOrderStatus(OrderStatus.ORDER_COMPLETE);
+
         showDateUpdate(showDateId, seatIds.size());
 
         seatHoldingService.seatHoldingUnLock(seatIds);
@@ -117,7 +122,7 @@ public class BookingService {
 
     private void checkCancelBookingTime(ShowDate showDate) {
         if (LocalDate.now().isAfter(showDate.getDate())) {
-            throw new CustomException(FORBIDDEN, "공연 시작 날짜 이전에만 취소 가능합니다.");
+            throw new CustomException(BAD_REQUEST, "공연 시작 날짜 이전에만 취소 가능합니다.");
         }
     }
 }

--- a/src/main/java/com/example/picket/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/picket/domain/order/controller/OrderController.java
@@ -1,0 +1,53 @@
+package com.example.picket.domain.order.controller;
+
+import com.example.picket.common.annotation.Auth;
+import com.example.picket.common.dto.AuthUser;
+import com.example.picket.common.dto.PageResponse;
+import com.example.picket.domain.order.dto.response.OrderResponse;
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.order.repository.OrderRepository;
+import com.example.picket.domain.order.service.OrderQueryService;
+import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/")
+@Tag(name = "주문 조회 API", description = "주문 다건 조회, 단건 조회 기능 API입니다.")
+public class OrderController {
+
+    private final OrderQueryService orderQueryService;
+
+    @Operation(summary = "주문 단건 조회", description = "주문을 단건 조회할 수 있습니다.")
+    @GetMapping("orders/{orderId}")
+    public ResponseEntity<OrderResponse> getOrder(
+            @PathVariable Long orderId,
+            @Auth AuthUser authUser) {
+        Order order = orderQueryService.getOrder(authUser.getId(), orderId);
+        OrderResponse orderResponse = OrderResponse.toDto(order);
+        return ResponseEntity.ok(orderResponse);
+    }
+
+    @Operation(summary = "주문 다건 조회", description = "주문을 다건 조회할 수 있습니다.")
+    @GetMapping("orders")
+    public ResponseEntity<PageResponse<OrderResponse>> getOrders(
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "1") int page,
+            @Auth AuthUser authUser
+    ) {
+        Page<OrderResponse> orderResponse = orderQueryService.getOrders(size, page, authUser.getId()).map(OrderResponse::toDto);
+        PageResponse<OrderResponse> pageOrderResponse = PageResponse.toDto(orderResponse);
+        return ResponseEntity.ok(pageOrderResponse);
+    }
+}

--- a/src/main/java/com/example/picket/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/picket/domain/order/dto/response/OrderResponse.java
@@ -1,0 +1,34 @@
+package com.example.picket.domain.order.dto.response;
+
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
+import com.example.picket.domain.ticket.entity.Ticket;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class OrderResponse {
+
+    private Long id;
+
+    private Long userId;
+
+    private BigDecimal totalPrice;
+
+    private List<GetTicketResponse> tickets;
+
+    private OrderResponse(Order order) {
+        this.id = order.getId();
+        this.userId = order.getUser().getId();
+        this.totalPrice = order.getTotalPrice();
+        this.tickets = order.getTicket().stream().map(GetTicketResponse::toDto).toList();
+    }
+
+    public static OrderResponse toDto(Order order) {
+        return new OrderResponse(order);
+    }
+
+}

--- a/src/main/java/com/example/picket/domain/order/entity/Order.java
+++ b/src/main/java/com/example/picket/domain/order/entity/Order.java
@@ -1,0 +1,48 @@
+package com.example.picket.domain.order.entity;
+
+import com.example.picket.common.entity.BaseEntity;
+import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private BigDecimal totalPrice;
+
+    @OneToMany(mappedBy = "order")
+    private List<Ticket> ticket = new ArrayList<>();
+
+    private Order(User user, BigDecimal totalPrice, List<Ticket> ticket) {
+        this.user = user;
+        this.totalPrice = totalPrice;
+        this.ticket = ticket;
+    }
+
+    public static Order toEntity(User user, BigDecimal totalPrice, List<Ticket> tickets) {
+        Order order =  new Order(user, totalPrice, tickets);
+        for (Ticket ticket : tickets) {
+            ticket.setOrder(order);
+        }
+        return order;
+    }
+}

--- a/src/main/java/com/example/picket/domain/order/entity/Order.java
+++ b/src/main/java/com/example/picket/domain/order/entity/Order.java
@@ -1,6 +1,7 @@
 package com.example.picket.domain.order.entity;
 
 import com.example.picket.common.entity.BaseEntity;
+import com.example.picket.common.enums.OrderStatus;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -29,17 +30,25 @@ public class Order extends BaseEntity {
     @Column(nullable = false)
     private BigDecimal totalPrice;
 
+    @Column(nullable = false)
+    private OrderStatus orderStatus;
+
     @OneToMany(mappedBy = "order")
     private List<Ticket> ticket = new ArrayList<>();
 
-    private Order(User user, BigDecimal totalPrice, List<Ticket> ticket) {
+    public void updateOrderStatus(OrderStatus status) {
+        this.orderStatus = status;
+    }
+
+    private Order(User user, BigDecimal totalPrice, OrderStatus orderStatus, List<Ticket> ticket) {
         this.user = user;
         this.totalPrice = totalPrice;
+        this.orderStatus = orderStatus;
         this.ticket = ticket;
     }
 
-    public static Order toEntity(User user, BigDecimal totalPrice, List<Ticket> tickets) {
-        Order order =  new Order(user, totalPrice, tickets);
+    public static Order toEntity(User user, BigDecimal totalPrice, OrderStatus orderStatus, List<Ticket> tickets) {
+        Order order =  new Order(user, totalPrice,orderStatus, tickets);
         for (Ticket ticket : tickets) {
             ticket.setOrder(order);
         }

--- a/src/main/java/com/example/picket/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/picket/domain/order/repository/OrderRepository.java
@@ -1,15 +1,23 @@
 package com.example.picket.domain.order.repository;
 
 import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    @EntityGraph(attributePaths = "user, ticket")
-    Optional<Order> findByUser(User user);
+    @EntityGraph(attributePaths = {"user", "ticket"})
+    Optional<Order> findByIdAndUser(Long orderId, User user);
+
+    @EntityGraph(attributePaths = {"user", "ticket"})
+    Page<Order> findByUser(User user, Pageable pageable);
 
 }

--- a/src/main/java/com/example/picket/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/picket/domain/order/repository/OrderRepository.java
@@ -1,0 +1,15 @@
+package com.example.picket.domain.order.repository;
+
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.user.entity.User;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @EntityGraph(attributePaths = "user, ticket")
+    Optional<Order> findByUser(User user);
+
+}

--- a/src/main/java/com/example/picket/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/example/picket/domain/order/service/OrderCommandService.java
@@ -1,5 +1,6 @@
 package com.example.picket.domain.order.service;
 
+import com.example.picket.common.enums.OrderStatus;
 import com.example.picket.domain.order.entity.Order;
 import com.example.picket.domain.order.repository.OrderRepository;
 import com.example.picket.domain.ticket.entity.Ticket;
@@ -22,7 +23,7 @@ public class OrderCommandService {
         BigDecimal totalPrice = tickets.stream()
                 .map(Ticket::getPrice)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        Order order = Order.toEntity(user, totalPrice, tickets);
+        Order order = Order.toEntity(user, totalPrice, OrderStatus.ORDER_PENDING, tickets);
         orderRepository.save(order);
         return order;
     }

--- a/src/main/java/com/example/picket/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/example/picket/domain/order/service/OrderCommandService.java
@@ -22,6 +22,8 @@ public class OrderCommandService {
         BigDecimal totalPrice = tickets.stream()
                 .map(Ticket::getPrice)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        return Order.toEntity(user, totalPrice, tickets);
+        Order order = Order.toEntity(user, totalPrice, tickets);
+        orderRepository.save(order);
+        return order;
     }
 }

--- a/src/main/java/com/example/picket/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/example/picket/domain/order/service/OrderCommandService.java
@@ -1,0 +1,27 @@
+package com.example.picket.domain.order.service;
+
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.order.repository.OrderRepository;
+import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderCommandService {
+
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public Order createOrder(User user, List<Ticket> tickets) {
+        BigDecimal totalPrice = tickets.stream()
+                .map(Ticket::getPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return Order.toEntity(user, totalPrice, tickets);
+    }
+}

--- a/src/main/java/com/example/picket/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/example/picket/domain/order/service/OrderQueryService.java
@@ -1,0 +1,30 @@
+package com.example.picket.domain.order.service;
+
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.order.repository.OrderRepository;
+import com.example.picket.domain.user.entity.User;
+import com.example.picket.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class OrderQueryService {
+
+    private final OrderRepository orderRepository;
+    private final UserQueryService userQueryService;
+
+    @Transactional(readOnly = true)
+    public Order getOrder(Long userId, Long orderId) {
+
+        User user = userQueryService.getUser(userId);
+
+        Order foundOrder = orderRepository.findByUser(user).orElseThrow(
+                () -> new CustomException(NOT_FOUND, "존재하지 않는 Order입니다."));
+        return foundOrder;
+    }
+}

--- a/src/main/java/com/example/picket/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/example/picket/domain/order/service/OrderQueryService.java
@@ -6,8 +6,14 @@ import com.example.picket.domain.order.repository.OrderRepository;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -20,11 +26,17 @@ public class OrderQueryService {
 
     @Transactional(readOnly = true)
     public Order getOrder(Long userId, Long orderId) {
-
         User user = userQueryService.getUser(userId);
-
-        Order foundOrder = orderRepository.findByUser(user).orElseThrow(
+        return orderRepository.findByIdAndUser(orderId, user).orElseThrow(
                 () -> new CustomException(NOT_FOUND, "존재하지 않는 Order입니다."));
-        return foundOrder;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Order> getOrders(int size, int page, Long userId) {
+        User user = userQueryService.getUser(userId);
+        Sort sortStandard = Sort.by("createdAt").descending();
+        Pageable pageable = PageRequest.of(page - 1, size, sortStandard);
+
+        return orderRepository.findByUser(user, pageable);
     }
 }

--- a/src/main/java/com/example/picket/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/example/picket/domain/seat/repository/SeatRepository.java
@@ -1,5 +1,6 @@
 package com.example.picket.domain.seat.repository;
 
+import com.example.picket.common.enums.SeatStatus;
 import com.example.picket.domain.seat.entity.Seat;
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +16,5 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     @Query("SELECT s FROM Seat s JOIN FETCH s.showDate sd JOIN FETCH sd.show WHERE s.id = :seatId")
     Optional<Seat> findByIdWithShowDateAndShow(@Param("seatId") Long seatId);
 
+    List<Seat> findAllBySeatStatus(SeatStatus seatStatus);
 }

--- a/src/main/java/com/example/picket/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/example/picket/domain/seat/repository/SeatRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-    List<Seat> findAllByShowDateId(Long showDateId);
+    @Query("SELECT s FROM Seat s WHERE s.showDate.id = :showDateId AND s.seatStatus = 'AVAILABLE'")
+    List<Seat> findAllByShowDateId(@Param("showDateId") Long showDateId);
 
     @Query("SELECT s FROM Seat s JOIN FETCH s.showDate sd JOIN FETCH sd.show WHERE s.id = :seatId")
     Optional<Seat> findByIdWithShowDateAndShow(@Param("seatId") Long seatId);

--- a/src/main/java/com/example/picket/domain/seat_holding/controller/SeatHoldingController.java
+++ b/src/main/java/com/example/picket/domain/seat_holding/controller/SeatHoldingController.java
@@ -1,9 +1,9 @@
-package com.example.picket.domain.booking.controller;
+package com.example.picket.domain.seat_holding.controller;
 
 import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.dto.AuthUser;
-import com.example.picket.domain.booking.dto.request.SeatHoldingRequest;
-import com.example.picket.domain.booking.service.SeatHoldingService;
+import com.example.picket.domain.seat_holding.dto.request.SeatHoldingRequest;
+import com.example.picket.domain.seat_holding.service.SeatHoldingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/picket/domain/seat_holding/dto/request/SeatHoldingRequest.java
+++ b/src/main/java/com/example/picket/domain/seat_holding/dto/request/SeatHoldingRequest.java
@@ -12,5 +12,5 @@ public class SeatHoldingRequest {
 
     @Schema(description = "선점할 좌석 ID", example = "[1]")
     @NotNull(message = "좌석 ID는 필수 입력값입니다.")
-    private List<Long> seatIds = new ArrayList<>();
+    private final List<Long> seatIds = new ArrayList<>();
 }

--- a/src/main/java/com/example/picket/domain/seat_holding/dto/request/SeatHoldingRequest.java
+++ b/src/main/java/com/example/picket/domain/seat_holding/dto/request/SeatHoldingRequest.java
@@ -1,4 +1,4 @@
-package com.example.picket.domain.booking.dto.request;
+package com.example.picket.domain.seat_holding.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/example/picket/domain/seat_holding/service/SeatHoldingService.java
+++ b/src/main/java/com/example/picket/domain/seat_holding/service/SeatHoldingService.java
@@ -29,7 +29,7 @@ public class SeatHoldingService {
     private final SeatQueryService seatQueryService;
     private final ShowQueryService showQueryService;
 
-    private final String KEY_PREFIX = "seat-holding-lock:seat:";
+    private final String KEY_PREFIX = "SEAT-HOLDING-LOCK:SEAT:";
     private final Duration HOLDING_DURATION = Duration.ofMinutes(30);
 
     @Transactional

--- a/src/main/java/com/example/picket/domain/seat_holding/service/SeatHoldingService.java
+++ b/src/main/java/com/example/picket/domain/seat_holding/service/SeatHoldingService.java
@@ -5,6 +5,9 @@ import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.seat.service.SeatQueryService;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.show.service.ShowQueryService;
+import com.example.picket.domain.ticket.service.TicketQueryService;
+import com.example.picket.domain.user.entity.User;
+import com.example.picket.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RBucket;
 import org.redisson.api.RedissonClient;
@@ -32,7 +35,7 @@ public class SeatHoldingService {
     @Transactional
     public void seatHoldingLock(Long userId, Long showId, List<Long> seatIds) {
 
-        checkLimit(showId, seatIds);
+        checkSeatLimit(showId, seatIds);
 
         List<Long> successfullyLockedSeats = new ArrayList<>();
 
@@ -80,7 +83,7 @@ public class SeatHoldingService {
         }
     }
 
-    private void checkLimit(Long showId, List<Long> seatIds) {
+    private void checkSeatLimit(Long showId, List<Long> seatIds) {
         Show foundShow = showQueryService.getShow(showId);
         if (foundShow.getTicketsLimitPerUser() < seatIds.size()) {
             throw new CustomException(CONFLICT, "선택 가능한 좌석 개수를 초과하였습니다.");

--- a/src/main/java/com/example/picket/domain/seat_holding/service/SeatHoldingService.java
+++ b/src/main/java/com/example/picket/domain/seat_holding/service/SeatHoldingService.java
@@ -1,8 +1,7 @@
-package com.example.picket.domain.booking.service;
+package com.example.picket.domain.seat_holding.service;
 
 import com.example.picket.common.enums.SeatStatus;
 import com.example.picket.common.exception.CustomException;
-import com.example.picket.domain.seat.entity.Seat;
 import com.example.picket.domain.seat.service.SeatQueryService;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.show.service.ShowQueryService;
@@ -15,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;

--- a/src/main/java/com/example/picket/domain/show/entity/ShowDate.java
+++ b/src/main/java/com/example/picket/domain/show/entity/ShowDate.java
@@ -53,14 +53,14 @@ public class ShowDate extends BaseEntity {
     @JoinColumn(name = "show_id", nullable = false)
     private Show show;
 
-    public void updateCountOnBooking() {
-        this.availableSeatCount -= 1;
-        this.reservedSeatCount += 1;
+    public void updateCountOnBooking(int count) {
+        this.availableSeatCount -= count;
+        this.reservedSeatCount += count;
     }
 
-    public void updateCountOnCancellation() {
-        this.reservedSeatCount -= 1;
-        this.availableSeatCount += 1;
+    public void updateCountOnCancellation(int count) {
+        this.reservedSeatCount -= count;
+        this.availableSeatCount += count;
     }
 
     private ShowDate(LocalDate date, LocalTime startTime, LocalTime endTime, Integer totalSeatCount,
@@ -102,11 +102,11 @@ public class ShowDate extends BaseEntity {
         this.availableSeatCount = this.totalSeatCount - this.reservedSeatCount;
     }
 
-    public void updateCountOnCancellation(int count) {
-        if (this.reservedSeatCount - count < 0) {
-            throw new IllegalStateException("취소할 수 있는 좌석 수가 부족합니다.");
-        }
-        this.reservedSeatCount -= count;
-        this.availableSeatCount = this.totalSeatCount - this.reservedSeatCount;
-    }
+//    public void updateCountOnCancellation(int count) {
+//        if (this.reservedSeatCount - count < 0) {
+//            throw new IllegalStateException("취소할 수 있는 좌석 수가 부족합니다.");
+//        }
+//        this.reservedSeatCount -= count;
+//        this.availableSeatCount = this.totalSeatCount - this.reservedSeatCount;
+//    }
 }

--- a/src/main/java/com/example/picket/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/example/picket/domain/ticket/controller/TicketController.java
@@ -33,15 +33,15 @@ public class TicketController {
     private final TicketCommandService ticketCommandService;
     private final TicketQueryService ticketQueryService;
 
-    @Operation(summary = "티켓 생성", description = "티켓을 생성할 수 있습니다.")
-    @PostMapping("seats/{seatId}/tickets")
-    @AuthPermission(role = UserRole.USER)
-    public ResponseEntity<CreateTicketResponse> createTicket(
-            @PathVariable Long seatId,
-            @Auth AuthUser authUser) {
-        Ticket ticket = ticketCommandService.createTicket(authUser.getId(), authUser.getUserRole(), seatId);
-        return ResponseEntity.ok(CreateTicketResponse.toDto(ticket));
-    }
+//    @Operation(summary = "티켓 생성", description = "티켓을 생성할 수 있습니다.")
+//    @PostMapping("seats/{seatId}/tickets")
+//    @AuthPermission(role = UserRole.USER)
+//    public ResponseEntity<CreateTicketResponse> createTicket(
+//            @PathVariable Long seatId,
+//            @Auth AuthUser authUser) {
+//        Ticket ticket = ticketCommandService.createTicket(authUser.getId(), authUser.getUserRole(), seatId);
+//        return ResponseEntity.ok(CreateTicketResponse.toDto(ticket));
+//    }
 
     @Operation(summary = "티켓 다건 조회", description = "티켓을 다건 조회할 수 있습니다.")
     @GetMapping("tickets")

--- a/src/main/java/com/example/picket/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/example/picket/domain/ticket/controller/TicketController.java
@@ -65,12 +65,12 @@ public class TicketController {
         return ResponseEntity.ok(GetTicketResponse.toDto(ticket));
     }
 
-    @Operation(summary = "티켓 삭제", description = "티켓을 삭제할 수 있습니다.")
-    @PutMapping("tickets/{ticketId}")
-    public ResponseEntity<DeleteTicketResponse> deleteTicket(
-            @PathVariable Long ticketId,
-            @Auth AuthUser authUser) {
-        Ticket ticket = ticketCommandService.deleteTicket(ticketId, authUser.getId());
-        return ResponseEntity.ok(DeleteTicketResponse.toDto(ticket));
-    }
+//    @Operation(summary = "티켓 삭제", description = "티켓을 삭제할 수 있습니다.")
+//    @PutMapping("tickets/{ticketId}")
+//    public ResponseEntity<DeleteTicketResponse> deleteTicket(
+//            @PathVariable Long ticketId,
+//            @Auth AuthUser authUser) {
+//        Ticket ticket = ticketCommandService.deleteTicket(ticketId, authUser.getId());
+//        return ResponseEntity.ok(DeleteTicketResponse.toDto(ticket));
+//    }
 }

--- a/src/main/java/com/example/picket/domain/ticket/entity/Ticket.java
+++ b/src/main/java/com/example/picket/domain/ticket/entity/Ticket.java
@@ -2,12 +2,12 @@ package com.example.picket.domain.ticket.entity;
 
 import com.example.picket.common.entity.BaseEntity;
 import com.example.picket.common.enums.TicketStatus;
+import com.example.picket.domain.order.entity.Order;
 import com.example.picket.domain.seat.entity.Seat;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,8 +42,16 @@ public class Ticket extends BaseEntity {
     @JoinColumn(name = "seat_id", nullable = false)
     private Seat seat;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
     public void updateTicketStatus(TicketStatus ticketStatus) {
         this.status = ticketStatus;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
     }
 
     private Ticket(User user, Show show, Seat seat, BigDecimal price, TicketStatus status) {

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
@@ -21,6 +21,7 @@ import com.example.picket.domain.user.service.UserQueryService;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -158,6 +159,19 @@ public class TicketCommandService {
         ticketRepository.save(ticket);
         return ticket;
     }
+
+    @Transactional
+    public List<Ticket> deleteTicket(User user, List<Long> ticketIds) {
+        return ticketIds.stream().map(ticketId -> {
+            Ticket ticket = ticketRepository.findByTicketId(ticketId).orElseThrow();
+            validateTicketStatus(ticket); // 티켓 상태 검증
+            validateUserInfo(user.getId(), ticket); // 티켓의 유저 정보 검증
+            ticket.updateTicketStatus(TicketStatus.TICKET_CANCELED);
+            return ticket;
+        }).toList();
+
+    }
+
 
 
 }

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
@@ -14,6 +14,7 @@ import com.example.picket.domain.seat.service.SeatQueryService;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.show.entity.ShowDate;
 import com.example.picket.domain.show.service.ShowDateQueryService;
+import com.example.picket.domain.show.service.ShowQueryService;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.ticket.repository.TicketRepository;
 import com.example.picket.domain.user.entity.User;
@@ -35,6 +36,7 @@ public class TicketCommandService {
     private final UserQueryService userQueryService;
     private final SeatQueryService seatQueryService;
     private final ShowDateQueryService showDateQueryService;
+    private final ShowQueryService showQueryService;
 
     @Transactional
     public Ticket createTicket(Long userId, UserRole userRole, Long seatId) {
@@ -51,7 +53,7 @@ public class TicketCommandService {
 
         validateSeat(foundSeat); // 좌석 검증
 
-        foundShowDate.updateCountOnBooking(); //showDate 필드 업데이트
+        //foundShowDate.updateCountOnBooking(); //showDate 필드 업데이트
 
         Ticket ticket = Ticket.toEntity(foundUser, foundShow, foundSeat, foundPrice, TicketStatus.TICKET_CREATED);
 
@@ -81,7 +83,7 @@ public class TicketCommandService {
 
         ticket.updateTicketStatus(TicketStatus.TICKET_CANCELED);
 
-        foundshowDate.updateCountOnCancellation(); // showDate 필드 업데이트
+        //foundshowDate.updateCountOnCancellation(); // showDate 필드 업데이트
 
         foundSeat.updateSeatStatus(SeatStatus.AVAILABLE); // 좌석 상태 업데이트
 
@@ -148,6 +150,13 @@ public class TicketCommandService {
         if (reservedTicketCount >= show.getTicketsLimitPerUser()) {
             throw new CustomException(CONFLICT, "예매 가능한 티켓 수를 초과합니다.");
         }
+    }
+
+
+    public Ticket createTicketVer2 (User user, Show show, Seat seat, TicketStatus ticketStatus) {
+        Ticket ticket = Ticket.toEntity(user, show, seat, seat.getPrice(), ticketStatus);
+        ticketRepository.save(ticket);
+        return ticket;
     }
 
 

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
@@ -7,6 +7,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.example.picket.common.enums.SeatStatus;
 import com.example.picket.common.enums.TicketStatus;
+import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.seat.entity.Seat;
 import com.example.picket.domain.seat.service.SeatQueryService;
@@ -19,6 +20,7 @@ import com.example.picket.domain.ticket.repository.TicketRepository;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserQueryService;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,112 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TicketCommandService {
 
     private final TicketRepository ticketRepository;
-    private final UserQueryService userQueryService;
     private final SeatQueryService seatQueryService;
-    private final ShowDateQueryService showDateQueryService;
-    private final ShowQueryService showQueryService;
-
-//    @Transactional
-//    public Ticket createTicket(Long userId, UserRole userRole, Long seatId) {
-//
-//        Seat foundSeat = getSeat(seatId);
-//        Show foundShow = foundSeat.getShowDate().getShow();
-//        User foundUser = getUser(userId);
-//        BigDecimal foundPrice = foundSeat.getPrice();
-//        ShowDate foundShowDate = foundSeat.getShowDate();
-//
-//        validateTicketCreationTime(foundShow); // 예매 시간 검증
-//
-//        validateAvailableTicketCount(foundUser, foundShow); // 예매 가능 티켓 개수 검증
-//
-//        validateSeat(foundSeat); // 좌석 검증
-//
-//        //foundShowDate.updateCountOnBooking(); //showDate 필드 업데이트
-//
-//        Ticket ticket = Ticket.toEntity(foundUser, foundShow, foundSeat, foundPrice, TicketStatus.TICKET_CREATED);
-//
-//        foundSeat.updateSeatStatus(SeatStatus.RESERVED); // 좌석 상태 업데이트
-//
-//        ticketRepository.save(ticket);
-//
-//        return ticket;
-//
-//    }
-
-//    @Transactional
-//    public Ticket deleteTicket(Long ticketId, Long userId) {
-//
-//        Ticket ticket = ticketRepository.findByTicketId(ticketId).orElseThrow(
-//                () -> new CustomException(NOT_FOUND, "존재하지 않는 Ticket입니다.")
-//        );
-//
-//        ShowDate foundshowDate = getShowDate(ticket.getShow());
-//        Seat foundSeat = getSeat(ticket.getSeat().getId());
-//
-//        validateTicketDeletionTime(foundshowDate); // 취소 시간 검증
-//
-//        validateTicketStatus(ticket); // 티켓 상태 검증
-//
-//        validateUserInfo(userId, ticket); // 티켓의 유저 정보 검증
-//
-//        ticket.updateTicketStatus(TicketStatus.TICKET_CANCELED);
-//
-//        //foundshowDate.updateCountOnCancellation(); // showDate 필드 업데이트
-//
-//        foundSeat.updateSeatStatus(SeatStatus.AVAILABLE); // 좌석 상태 업데이트
-//
-//        // TODO : 환불 처리 로직 구현 ?
-//        // 환불이 성공적으로 끝났다면, TicketStatus와 deletedAt 업데이트
-//
-//        ticket.updateTicketStatus(TicketStatus.TICKET_EXPIRED); // 티켓 상태 업데이트
-//
-//        ticket.updateDeletedAt(LocalDateTime.now()); // 티켓 소프트 딜리트
-//
-//        return ticket;
-//    }
-
-//    private User getUser(Long userId) {
-//        return userQueryService.getUser(userId);
-//    }
-//
-//    private Seat getSeat(Long seatId) {
-//        return seatQueryService.getSeat(seatId);
-//    }
-//
-//    private ShowDate getShowDate(Show show) {
-//        return showDateQueryService.getShowDateByShow(show);
-//    }
-//
-//    private void validateSeat(Seat seat) {
-//        if (seat.getSeatStatus() == SeatStatus.RESERVED) {
-//            throw new CustomException(CONFLICT, "이미 예매된 좌석입니다.");
-//        }
-//    }
-//
-//    private void validateTicketCreationTime(Show show) {
-//        LocalDateTime now = LocalDateTime.now();
-//
-//        if (now.isBefore(show.getReservationStart())) {
-//            throw new CustomException(BAD_REQUEST, "예매 시작 시간 전입니다.");
-//        }
-//
-//        if (now.isAfter(show.getReservationEnd())) {
-//            throw new CustomException(BAD_REQUEST, "예매 종료 시간 이후 입니다.");
-//        }
-//    }
-//
-//    private void validateTicketDeletionTime(ShowDate showDate) {
-//        if (LocalDate.now().isAfter(showDate.getDate())) {
-//            throw new CustomException(FORBIDDEN, "공연 시작 날짜 이전에만 취소 가능합니다.");
-//        }
-//    }
-//
-//    private void validateAvailableTicketCount(User user, Show show) {
-//        int reservedTicketCount = ticketRepository.countTicketByUserAndShowWithTicketStatus(user, show, TicketStatus.TICKET_CREATED);
-//        if (reservedTicketCount >= show.getTicketsLimitPerUser()) {
-//            throw new CustomException(CONFLICT, "예매 가능한 티켓 수를 초과합니다.");
-//        }
-//    }
 
     @Transactional
     public List<Ticket> createTicket(User user, Show show, List<Long> seatIds) {

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
@@ -170,7 +170,7 @@ public class TicketCommandService {
     }
 
     private void validateTicketStatus(Ticket ticket) {
-        if (ticket.getStatus() == TicketStatus.TICKET_EXPIRED) {
+        if (ticket.getStatus() == TicketStatus.TICKET_CANCELED) {
             throw new CustomException(CONFLICT, "이미 취소된 티켓입니다.");
         }
     }

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
@@ -157,6 +157,7 @@ public class TicketCommandService {
             validateTicketStatus(ticket); // 티켓 상태 검증
             validateUserInfo(user.getId(), ticket); // 티켓의 유저 정보 검증
             ticket.updateTicketStatus(TicketStatus.TICKET_CANCELED);
+            ticket.getSeat().updateSeatStatus(SeatStatus.AVAILABLE);
             return ticket;
         }).toList();
 

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
@@ -7,7 +7,6 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.example.picket.common.enums.SeatStatus;
 import com.example.picket.common.enums.TicketStatus;
-import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.seat.entity.Seat;
 import com.example.picket.domain.seat.service.SeatQueryService;
@@ -20,7 +19,6 @@ import com.example.picket.domain.ticket.repository.TicketRepository;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserQueryService;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -38,32 +36,32 @@ public class TicketCommandService {
     private final ShowDateQueryService showDateQueryService;
     private final ShowQueryService showQueryService;
 
-    @Transactional
-    public Ticket createTicket(Long userId, UserRole userRole, Long seatId) {
-
-        Seat foundSeat = getSeat(seatId);
-        Show foundShow = foundSeat.getShowDate().getShow();
-        User foundUser = getUser(userId);
-        BigDecimal foundPrice = foundSeat.getPrice();
-        ShowDate foundShowDate = foundSeat.getShowDate();
-
-        validateTicketCreationTime(foundShow); // 예매 시간 검증
-
-        validateAvailableTicketCount(foundUser, foundShow); // 예매 가능 티켓 개수 검증
-
-        validateSeat(foundSeat); // 좌석 검증
-
-        //foundShowDate.updateCountOnBooking(); //showDate 필드 업데이트
-
-        Ticket ticket = Ticket.toEntity(foundUser, foundShow, foundSeat, foundPrice, TicketStatus.TICKET_CREATED);
-
-        foundSeat.updateSeatStatus(SeatStatus.RESERVED); // 좌석 상태 업데이트
-
-        ticketRepository.save(ticket);
-
-        return ticket;
-
-    }
+//    @Transactional
+//    public Ticket createTicket(Long userId, UserRole userRole, Long seatId) {
+//
+//        Seat foundSeat = getSeat(seatId);
+//        Show foundShow = foundSeat.getShowDate().getShow();
+//        User foundUser = getUser(userId);
+//        BigDecimal foundPrice = foundSeat.getPrice();
+//        ShowDate foundShowDate = foundSeat.getShowDate();
+//
+//        validateTicketCreationTime(foundShow); // 예매 시간 검증
+//
+//        validateAvailableTicketCount(foundUser, foundShow); // 예매 가능 티켓 개수 검증
+//
+//        validateSeat(foundSeat); // 좌석 검증
+//
+//        //foundShowDate.updateCountOnBooking(); //showDate 필드 업데이트
+//
+//        Ticket ticket = Ticket.toEntity(foundUser, foundShow, foundSeat, foundPrice, TicketStatus.TICKET_CREATED);
+//
+//        foundSeat.updateSeatStatus(SeatStatus.RESERVED); // 좌석 상태 업데이트
+//
+//        ticketRepository.save(ticket);
+//
+//        return ticket;
+//
+//    }
 
     @Transactional
     public Ticket deleteTicket(Long ticketId, Long userId) {
@@ -153,8 +151,10 @@ public class TicketCommandService {
     }
 
 
-    public Ticket createTicketVer2 (User user, Show show, Seat seat, TicketStatus ticketStatus) {
+    @Transactional
+    public Ticket createTicket(User user, Show show, Seat seat, TicketStatus ticketStatus) {
         Ticket ticket = Ticket.toEntity(user, show, seat, seat.getPrice(), ticketStatus);
+        seat.updateSeatStatus(SeatStatus.RESERVED);
         ticketRepository.save(ticket);
         return ticket;
     }

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketQueryService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketQueryService.java
@@ -1,13 +1,13 @@
 package com.example.picket.domain.ticket.service;
 
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 import com.example.picket.common.enums.TicketStatus;
 import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.ticket.repository.TicketRepository;
 import java.util.List;
+
+import com.example.picket.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.http.HttpStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -54,4 +56,12 @@ public class TicketQueryService {
             throw new CustomException(FORBIDDEN, "본인이 예매한 티켓만 조회할 수 있습니다.");
         }
     }
+
+   @Transactional(readOnly = true)
+   public void checkTicketLimit (User user, Show show) {
+       int reservedTicketCount = ticketRepository.countTicketByUserAndShowWithTicketStatus(user, show, TicketStatus.TICKET_CREATED);
+       if (reservedTicketCount >= show.getTicketsLimitPerUser()) {
+           throw new CustomException(CONFLICT, "예매 가능한 티켓 수를 초과합니다.");
+       }
+   }
 }

--- a/src/test/java/com/example/picket/domain/booking/service/BookingServiceTest.java
+++ b/src/test/java/com/example/picket/domain/booking/service/BookingServiceTest.java
@@ -1,0 +1,197 @@
+package com.example.picket.domain.booking.service;
+
+import com.example.picket.common.enums.*;
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.order.service.OrderCommandService;
+import com.example.picket.domain.seat.entity.Seat;
+import com.example.picket.domain.seat_holding.service.SeatHoldingService;
+import com.example.picket.domain.show.entity.Show;
+import com.example.picket.domain.show.entity.ShowDate;
+import com.example.picket.domain.show.service.ShowDateQueryService;
+import com.example.picket.domain.show.service.ShowQueryService;
+import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.ticket.service.TicketCommandService;
+import com.example.picket.domain.ticket.service.TicketQueryService;
+import com.example.picket.domain.user.entity.User;
+import com.example.picket.domain.user.service.UserQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookingServiceTest {
+
+    @InjectMocks
+    private BookingService bookingService;
+
+    @Mock
+    private RedissonClient redissonClient;
+    @Mock
+    private RLock rLock;
+
+    @Mock private SeatHoldingService seatHoldingService;
+    @Mock private ShowQueryService showQueryService;
+    @Mock private UserQueryService userQueryService;
+    @Mock private ShowDateQueryService showDateQueryService;
+    @Mock private OrderCommandService orderCommandService;
+    @Mock private TicketCommandService ticketCommandService;
+    @Mock private TicketQueryService ticketQueryService;
+
+    private User user;
+    private Show show;
+    private Seat seat;
+    private ShowDate showDate;
+
+    @BeforeEach
+    void setUp() {
+        user = User.toEntity(
+                "user@example.com", "encodedPw", UserRole.USER, null, "nickname",
+                LocalDate.of(1990, 1, 1), Gender.MALE
+        );
+
+        show = Show.toEntity(
+                1L, "Show Title", "http://poster.url", Category.CONCERT, "Description",
+                "Location", LocalDateTime.now(), LocalDateTime.now().plusDays(1), 4
+        );
+
+        showDate = ShowDate.toEntity(LocalDate.now().plusDays(7), LocalTime.of(19, 0), LocalTime.of(20, 0), 1, 0, show);
+
+        seat = Seat.toEntity(Grade.A, 1, BigDecimal.valueOf(1000L), showDate);
+    }
+
+    @Test
+    void 성공적으로_예매할_수_있다() throws InterruptedException {
+        // given
+        Long showId = 1L;
+        Long showDateId = 1L;
+        Long userId = 1L;
+        List<Long> seatIds = Arrays.asList(1L);
+        BigDecimal price = BigDecimal.valueOf(100L);
+        List<Ticket> tickets = Arrays.asList(Ticket.toEntity(user, show, seat, price, TicketStatus.TICKET_CREATED));
+        Order order = Order.toEntity(user, price, OrderStatus.ORDER_COMPLETE, tickets);
+        order.updateOrderStatus(OrderStatus.ORDER_COMPLETE);
+
+        when(showQueryService.getShow(showId)).thenReturn(show);
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        when(showDateQueryService.getShowDate(showDateId)).thenReturn(showDate);
+        when(ticketCommandService.createTicket(user, show, seatIds)).thenReturn(tickets);
+        when(orderCommandService.createOrder(user, tickets)).thenReturn(order);
+        when(redissonClient.getFairLock(anyString())).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), any())).thenReturn(true);
+
+        // when
+        Order result = bookingService.booking(showId, showDateId, userId, seatIds);
+
+        // then
+        assertNotNull(result);
+        assertEquals(OrderStatus.ORDER_COMPLETE, result.getOrderStatus());
+        verify(seatHoldingService).seatHoldingCheck(userId, seatIds);
+        verify(ticketQueryService).checkTicketLimit(user, show);
+        verify(ticketCommandService).createTicket(user, show, seatIds);
+        verify(orderCommandService).createOrder(user, tickets);
+        verify(seatHoldingService).seatHoldingUnLock(seatIds);
+        verify(rLock).unlock();
+    }
+
+    @Test
+    void 예매_시작_시간_전_예매_시_예외가_발생한다() {
+        // given
+        Show show = mock(Show.class);
+        Long showId = 1L;
+        Long showDateId = 1L;
+        Long userId = 1L;
+        List<Long> seatIds = Arrays.asList(1L);
+        when(show.getReservationStart()).thenReturn(LocalDateTime.now().plusDays(1));
+        when(showQueryService.getShow(showId)).thenReturn(show);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                bookingService.booking(showId, showDateId, userId, seatIds));
+        assertEquals("예매 시작 시간 전입니다.", exception.getMessage());
+        verifyNoInteractions(seatHoldingService, ticketQueryService, ticketCommandService, orderCommandService);
+    }
+
+    @Test
+    void booking_AfterReservationEnd_ThrowsException() {
+        // Arrange
+        Show show = mock(Show.class);
+        Long showId = 1L;
+        Long showDateId = 1L;
+        Long userId = 1L;
+        List<Long> seatIds = Arrays.asList(1L);
+        when(show.getReservationStart()).thenReturn(LocalDateTime.now().minusDays(2));
+        when(show.getReservationEnd()).thenReturn(LocalDateTime.now().minusDays(1));
+        when(showQueryService.getShow(showId)).thenReturn(show);
+
+
+        // Act & Assert
+        CustomException exception = assertThrows(CustomException.class, () ->
+                bookingService.booking(showId, showDateId, userId, seatIds));
+        assertEquals("예매 종료 시간 이후 입니다.", exception.getMessage());
+        verifyNoInteractions(seatHoldingService, ticketQueryService, ticketCommandService, orderCommandService);
+    }
+
+    @Test
+    void 성공적으로_예매취소_할_수_있다() throws InterruptedException {
+        // given
+        Long showId = 1L;
+        Long showDateId = 1L;
+        Long userId = 1L;
+        List<Long> ticketIds = Arrays.asList(1L, 2L);
+        BigDecimal price = BigDecimal.valueOf(100L);
+        List<Ticket> canceledTickets = Arrays.asList(Ticket.toEntity(user, show, seat, price, TicketStatus.TICKET_CREATED));
+
+        when(showDateQueryService.getShowDate(showDateId)).thenReturn(showDate);
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        when(ticketCommandService.deleteTicket(user, ticketIds)).thenReturn(canceledTickets);
+        when(redissonClient.getFairLock(anyString())).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), any())).thenReturn(true);
+
+        // when
+        List<Ticket> result = bookingService.cancelBooking(showId, showDateId, userId, ticketIds);
+
+        // then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        verify(showDateQueryService, times(2)).getShowDate(showDateId);
+        verify(userQueryService).getUser(userId);
+        verify(ticketCommandService).deleteTicket(user, ticketIds);
+        verify(rLock).unlock();
+    }
+
+    @Test
+    void 공연날짜_이후_예매_취소_시_예외가_발생한다() {
+        // given
+        Long showId = 1L;
+        Long showDateId = 1L;
+        Long userId = 1L;
+        List<Long> ticketIds = Arrays.asList(1L, 2L);
+        ShowDate pastShowDate = ShowDate.toEntity(
+                LocalDate.now().minusDays(1), LocalTime.of(19, 0), LocalTime.of(20, 0), 100, 0, show
+        );
+
+        when(showDateQueryService.getShowDate(showDateId)).thenReturn(pastShowDate);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                bookingService.cancelBooking(showId, showDateId, userId, ticketIds));
+        assertEquals("공연 시작 날짜 이전에만 취소 가능합니다.", exception.getMessage());
+        verifyNoInteractions(userQueryService, ticketCommandService);
+    }
+}

--- a/src/test/java/com/example/picket/domain/order/service/OrderCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/order/service/OrderCommandServiceTest.java
@@ -1,0 +1,81 @@
+package com.example.picket.domain.order.service;
+
+import com.example.picket.common.enums.Gender;
+import com.example.picket.common.enums.OrderStatus;
+import com.example.picket.common.enums.TicketStatus;
+import com.example.picket.common.enums.UserRole;
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.order.repository.OrderRepository;
+import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderCommandServiceTest {
+
+    @InjectMocks
+    private OrderCommandService orderCommandService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    private User user;
+    private Ticket ticket1;
+    private Ticket ticket2;
+    private List<Ticket> tickets;
+
+    @BeforeEach
+    void setUp() {
+        // 사용자 생성
+        user = User.toEntity(
+                "user@example.com", "encodedPw", UserRole.USER, null, "nickname",
+                LocalDate.of(1990, 1, 1), Gender.MALE
+        );
+
+        // 티켓 목업 생성
+        ticket1 = mock(Ticket.class);
+        when(ticket1.getPrice()).thenReturn(BigDecimal.valueOf(10000));
+
+        ticket2 = mock(Ticket.class);
+        when(ticket2.getPrice()).thenReturn(BigDecimal.valueOf(15000));
+
+        tickets = Arrays.asList(ticket1, ticket2);
+    }
+
+    @Test
+    void createOrder_정상_생성() {
+        // Given
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        Order result = orderCommandService.createOrder(user, tickets);
+
+        // Then
+        assertNotNull(result);
+
+        // Order 엔티티 생성 검증
+        ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(orderCaptor.capture());
+
+        Order capturedOrder = orderCaptor.getValue();
+        assertEquals(user, capturedOrder.getUser());
+        assertEquals(BigDecimal.valueOf(25000), capturedOrder.getTotalPrice());
+        assertEquals(OrderStatus.ORDER_PENDING, capturedOrder.getOrderStatus());
+        assertEquals(tickets, capturedOrder.getTicket());
+    }
+}

--- a/src/test/java/com/example/picket/domain/order/service/OrderCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/order/service/OrderCommandServiceTest.java
@@ -2,7 +2,6 @@ package com.example.picket.domain.order.service;
 
 import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.OrderStatus;
-import com.example.picket.common.enums.TicketStatus;
 import com.example.picket.common.enums.UserRole;
 import com.example.picket.domain.order.entity.Order;
 import com.example.picket.domain.order.repository.OrderRepository;
@@ -21,7 +20,8 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -41,13 +41,11 @@ class OrderCommandServiceTest {
 
     @BeforeEach
     void setUp() {
-        // 사용자 생성
         user = User.toEntity(
                 "user@example.com", "encodedPw", UserRole.USER, null, "nickname",
                 LocalDate.of(1990, 1, 1), Gender.MALE
         );
 
-        // 티켓 목업 생성
         ticket1 = mock(Ticket.class);
         when(ticket1.getPrice()).thenReturn(BigDecimal.valueOf(10000));
 
@@ -58,17 +56,16 @@ class OrderCommandServiceTest {
     }
 
     @Test
-    void createOrder_정상_생성() {
-        // Given
+    void 티켓을_성공적으로_생성할_수_있다() {
+        // given
         when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        // When
+        // when
         Order result = orderCommandService.createOrder(user, tickets);
 
-        // Then
+        // then
         assertNotNull(result);
 
-        // Order 엔티티 생성 검증
         ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
         verify(orderRepository).save(orderCaptor.capture());
 

--- a/src/test/java/com/example/picket/domain/order/service/OrderQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/order/service/OrderQueryServiceTest.java
@@ -47,13 +47,11 @@ class OrderQueryServiceTest {
 
     @BeforeEach
     void setUp() {
-        // 사용자 생성
         user = User.toEntity(
                 "user@example.com", "encodedPw", UserRole.USER, null, "nickname",
                 LocalDate.of(1990, 1, 1), Gender.MALE
         );
 
-        // 주문 생성
         order1 = mock(Order.class);
         lenient().when(order1.getId()).thenReturn(1L);
         lenient().when(order1.getUser()).thenReturn(user);

--- a/src/test/java/com/example/picket/domain/order/service/OrderQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/order/service/OrderQueryServiceTest.java
@@ -1,0 +1,182 @@
+package com.example.picket.domain.order.service;
+
+import com.example.picket.common.enums.Gender;
+import com.example.picket.common.enums.OrderStatus;
+import com.example.picket.common.enums.UserRole;
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.order.repository.OrderRepository;
+import com.example.picket.domain.user.entity.User;
+import com.example.picket.domain.user.service.UserQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderQueryServiceTest {
+
+    @InjectMocks
+    private OrderQueryService orderQueryService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private UserQueryService userQueryService;
+
+    private User user;
+    private Order order1;
+    private Order order2;
+
+    @BeforeEach
+    void setUp() {
+        // 사용자 생성
+        user = User.toEntity(
+                "user@example.com", "encodedPw", UserRole.USER, null, "nickname",
+                LocalDate.of(1990, 1, 1), Gender.MALE
+        );
+
+        // 주문 생성
+        order1 = mock(Order.class);
+        lenient().when(order1.getId()).thenReturn(1L);
+        lenient().when(order1.getUser()).thenReturn(user);
+        lenient().when(order1.getTotalPrice()).thenReturn(BigDecimal.valueOf(20000));
+        lenient().when(order1.getOrderStatus()).thenReturn(OrderStatus.ORDER_PENDING);
+
+        order2 = mock(Order.class);
+        lenient().when(order2.getId()).thenReturn(2L);
+        lenient().when(order2.getUser()).thenReturn(user);
+        lenient().when(order2.getTotalPrice()).thenReturn(BigDecimal.valueOf(30000));
+        lenient().when(order2.getOrderStatus()).thenReturn(OrderStatus.ORDER_COMPLETE);
+    }
+
+    @Test
+    void 주문_단건_조회_시_정상적으로_조회할_수_있다() {
+        // Given
+        Long userId = 1L;
+        Long orderId = 1L;
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        when(orderRepository.findByIdAndUser(orderId, user)).thenReturn(Optional.of(order1));
+
+        // When
+        Order result = orderQueryService.getOrder(userId, orderId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(order1, result);
+        verify(userQueryService).getUser(userId);
+        verify(orderRepository).findByIdAndUser(orderId, user);
+    }
+
+    @Test
+    void 주문_단건_조회_시_존재하지_않는_주문일_경우_예외가_발생한다() {
+        // Given
+        Long userId = 1L;
+        Long orderId = 999L;
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        when(orderRepository.findByIdAndUser(orderId, user)).thenReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            orderQueryService.getOrder(userId, orderId);
+        });
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatus());
+        assertEquals("존재하지 않는 Order입니다.", exception.getMessage());
+        verify(userQueryService).getUser(userId);
+        verify(orderRepository).findByIdAndUser(orderId, user);
+    }
+
+    @Test
+    void 주문_다건_조회_시_정상적으로_조회할_수_있다() {
+        // Given
+        int size = 10;
+        int page = 1;
+        Long userId = 1L;
+        List<Order> orderList = Arrays.asList(order1, order2);
+        Page<Order> orderPage = new PageImpl<>(orderList);
+
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        when(orderRepository.findByUser(eq(user), any(PageRequest.class))).thenReturn(orderPage);
+
+        // When
+        Page<Order> result = orderQueryService.getOrders(size, page, userId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals(orderList, result.getContent());
+
+        verify(userQueryService).getUser(userId);
+        verify(orderRepository).findByUser(eq(user), any(PageRequest.class));
+    }
+
+    @Test
+    void 주문_다건_조회_시_페이지_파라미터_검증() {
+        // Given
+        int size = 20;
+        int page = 2;
+        Long userId = 1L;
+        Page<Order> emptyPage = Page.empty();
+
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        when(orderRepository.findByUser(eq(user), any(PageRequest.class))).thenReturn(emptyPage);
+
+        // When
+        orderQueryService.getOrders(size, page, userId);
+
+        // Then
+        verify(userQueryService).getUser(userId);
+
+        // PageRequest 객체 생성 검증
+        verify(orderRepository).findByUser(
+                eq(user),
+                argThat(pageRequest ->
+                        pageRequest.getPageNumber() == 1 &&
+                                pageRequest.getPageSize() == 20 &&
+                                pageRequest.getSort().equals(Sort.by("createdAt").descending())
+                )
+        );
+    }
+
+    @Test
+    void 주문_다건_조회_시_빈_결과일_경우() {
+        // Given
+        int size = 10;
+        int page = 1;
+        Long userId = 1L;
+        Page<Order> emptyPage = Page.empty();
+
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        when(orderRepository.findByUser(eq(user), any(PageRequest.class))).thenReturn(emptyPage);
+
+        // When
+        Page<Order> result = orderQueryService.getOrders(size, page, userId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(0, result.getTotalElements());
+        assertTrue(result.getContent().isEmpty());
+
+        verify(userQueryService).getUser(userId);
+        verify(orderRepository).findByUser(eq(user), any(PageRequest.class));
+    }
+
+}

--- a/src/test/java/com/example/picket/domain/ticket/service/TicketCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ticket/service/TicketCommandServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -62,7 +63,7 @@ class TicketCommandServiceTest {
     }
 
     @Test
-    void createTicket_정상_생성() {
+    void 티켓을_정상적으로_생성할_수_있다() {
         Long seatId = 1L;
 
         when(seatQueryService.getSeat(seatId)).thenReturn(seat);
@@ -76,7 +77,7 @@ class TicketCommandServiceTest {
     }
 
     @Test
-    void deleteTicket_정상_취소() {
+    void 티켓을_정상적으로_삭제할_수_있다() {
         Ticket ticket = mock(Ticket.class);
         when(ticket.getUser()).thenReturn(user);
         when(ticket.getStatus()).thenReturn(TicketStatus.TICKET_CREATED);
@@ -91,7 +92,7 @@ class TicketCommandServiceTest {
     }
 
     @Test
-    void deleteTicket_존재하지_않는_티켓() {
+    void 티켓_삭제_시_존재하지_않는_티켓을_삭제하려_할_경우_예외가_발생한다() {
         when(ticketRepository.findByTicketId(anyLong())).thenReturn(Optional.empty());
 
         CustomException exception = assertThrows(CustomException.class,
@@ -102,7 +103,7 @@ class TicketCommandServiceTest {
     }
 
     @Test
-    void deleteTicket_다른_유저_티켓_취소_시도() {
+    void 티켓_삭제_시_본인이_예매하지_않은_티켓을_삭제하려_할_경우_예외가_발생한다() {
         User anotherUser = User.toEntity(
                 "other@example.com", "pw", UserRole.USER, null, "other",
                 LocalDate.of(1991, 2, 2), Gender.FEMALE
@@ -110,9 +111,11 @@ class TicketCommandServiceTest {
         Ticket ticket = mock(Ticket.class);
         Seat seat = mock(Seat.class);
 
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(anotherUser, "id", 2L);
+
         when(ticket.getUser()).thenReturn(anotherUser);
         when(ticket.getStatus()).thenReturn(TicketStatus.TICKET_CREATED);
-        when(ticket.getSeat()).thenReturn(seat);  // 👈 추가된 부분
         when(ticketRepository.findByTicketId(anyLong())).thenReturn(Optional.of(ticket));
 
         CustomException exception = assertThrows(CustomException.class,
@@ -123,7 +126,7 @@ class TicketCommandServiceTest {
     }
 
     @Test
-    void deleteTicket_취소된_티켓_취소_시도() {
+    void 티켓_삭제_시_이미_삭제된_티켓을_삭제하려_할_경우_예외가_발생한다() {
         Ticket ticket = mock(Ticket.class);
         when(ticket.getStatus()).thenReturn(TicketStatus.TICKET_CANCELED);
         when(ticketRepository.findByTicketId(anyLong())).thenReturn(Optional.of(ticket));

--- a/src/test/java/com/example/picket/domain/ticket/service/TicketCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ticket/service/TicketCommandServiceTest.java
@@ -5,12 +5,9 @@ import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.seat.entity.Seat;
 import com.example.picket.domain.seat.service.SeatQueryService;
 import com.example.picket.domain.show.entity.Show;
-import com.example.picket.domain.show.entity.ShowDate;
-import com.example.picket.domain.show.service.ShowDateQueryService;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.ticket.repository.TicketRepository;
 import com.example.picket.domain.user.entity.User;
-import com.example.picket.domain.user.service.UserQueryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +23,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/com/example/picket/domain/ticket/service/TicketQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ticket/service/TicketQueryServiceTest.java
@@ -1,19 +1,9 @@
 package com.example.picket.domain.ticket.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.ticket.repository.TicketRepository;
 import com.example.picket.domain.user.entity.User;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,6 +12,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TicketQueryServiceTest {


### PR DESCRIPTION
📌 반영 브랜치
feat/booking -> dev

✅ 작업 내용
좌석 선점 후 예매, 예매취소, 주문 다건 조회, 주문 단건 조회 API 구현
기존 TicketCommandService의 createTicket, deleteTicket 리팩토링
선점 좌석 상태 업데이트 스케줄러 구현

🎯 단독 테스트 결과
Swagger 테스트 확인 + 테스트코드 확인 완료

🚨 연관 이슈
closes #93
closes #94
closes #95