### PR TITLE
S3/Image : S3 생성 및 이미지 저장, 고아객체 관리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,10 @@ jobs:
           AWS_REDIS_PORT: ${{ secrets.AWS_REDIS_PORT }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET_KEY: ${{ secrets.CLIENT_SECRET_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_S3_IMAGE_BUCKET: ${{ secrets.AWS_S3_IMAGE_BUCKET }}
+          AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
+          AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY  }}
         run: ./gradlew clean build --no-daemon -Dspring.profiles.active=prod
 
       # 6. JAR 파일 검증
@@ -61,13 +65,6 @@ jobs:
       # 7. ZIP 파일 생성
       - name: 📦 Create ZIP for CodeDeploy
         run: |
-          echo "AWS_RDS_URL=${{ secrets.AWS_RDS_URL }}" > .env
-          echo "AWS_RDS_USERNAME=${{ secrets.AWS_RDS_USERNAME }}" >> .env
-          echo "AWS_RDS_PASSWORD=${{ secrets.AWS_RDS_PASSWORD }}" >> .env
-          echo "AWS_REDIS_URL=${{ secrets.AWS_REDIS_URL }}" >> .env
-          echo "AWS_REDIS_PORT=${{ secrets.AWS_REDIS_PORT }}" >> .env
-          echo "CLIENT_ID=${{ secrets.CLIENT_ID }}" >> .env
-          echo "CLIENT_SECRET_KEY=${{ secrets.CLIENT_SECRET_KEY }}" >> .env
           zip -j ./$GITHUB_SHA.zip build/libs/picket.jar appspec.yml scripts/deploy.sh .env
         shell: bash
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,13 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    //swagger
+    // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
     // redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.37.0'
 
-    //webClient
+    // webClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // monitoring
@@ -70,6 +70,15 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // AWS
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
+
+    // S3
+    implementation "software.amazon.awssdk:s3:2.31.0"
+
+    // Scalr
+    implementation "org.imgscalr:imgscalr-lib:4.2"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/picket/common/dto/AuthUser.java
+++ b/src/main/java/com/example/picket/common/dto/AuthUser.java
@@ -17,7 +17,7 @@ public class AuthUser {
         this.userRole = userRole;
     }
 
-    public static AuthUser toEntity(Long id, UserRole userRole) {
+    public static AuthUser create(Long id, UserRole userRole) {
         return new AuthUser(id, userRole);
     }
 }

--- a/src/main/java/com/example/picket/common/dto/OAuthUser.java
+++ b/src/main/java/com/example/picket/common/dto/OAuthUser.java
@@ -15,7 +15,7 @@ public class OAuthUser {
         this.email = email;
     }
 
-    public static OAuthUser toEntity(String id,  String email) {
+    public static OAuthUser create(String id, String email) {
         return new OAuthUser(id, email);
     }
 }

--- a/src/main/java/com/example/picket/common/dto/PageResponse.java
+++ b/src/main/java/com/example/picket/common/dto/PageResponse.java
@@ -26,13 +26,13 @@ public class PageResponse<T> {
         this.totalPages = totalPages;
     }
 
-    public static <T> PageResponse<T> toDto(Page<T> page) {
+    public static <T> PageResponse<T> of(Page<T> page) {
         return new PageResponse<T>(
-            page.getContent(),
-            page.getSize(),
-            page.getNumber() + 1,
-            page.getTotalElements(),
-            page.getTotalPages()
+                page.getContent(),
+                page.getSize(),
+                page.getNumber() + 1,
+                page.getTotalElements(),
+                page.getTotalPages()
         );
     }
 }

--- a/src/main/java/com/example/picket/common/enums/ImageStatus.java
+++ b/src/main/java/com/example/picket/common/enums/ImageStatus.java
@@ -1,0 +1,6 @@
+package com.example.picket.common.enums;
+
+public enum ImageStatus {
+
+    PENDING, CREATED, REMOVED;
+}

--- a/src/main/java/com/example/picket/common/enums/ImageStatus.java
+++ b/src/main/java/com/example/picket/common/enums/ImageStatus.java
@@ -1,6 +1,0 @@
-package com.example.picket.common.enums;
-
-public enum ImageStatus {
-
-    PENDING, CREATED, REMOVED;
-}

--- a/src/main/java/com/example/picket/common/scheduler/ImageRemoveScheduler.java
+++ b/src/main/java/com/example/picket/common/scheduler/ImageRemoveScheduler.java
@@ -24,7 +24,7 @@ public class ImageRemoveScheduler {
     private final ShowImageRepository showImageRepository;
     private final S3Service s3Service;
 
-    @Scheduled(cron = "0 * * * * ?")
+    @Scheduled(cron = "0 0 * * * ?")
     @SchedulerLock(name = "IMAGE-REMOVED-SCHEDULER", lockAtLeastFor = "PT1M", lockAtMostFor = "PT5M")
 
     public void cleanUpRemovedImage() {

--- a/src/main/java/com/example/picket/common/scheduler/ImageRemoveScheduler.java
+++ b/src/main/java/com/example/picket/common/scheduler/ImageRemoveScheduler.java
@@ -1,0 +1,64 @@
+package com.example.picket.common.scheduler;
+
+import com.example.picket.common.service.S3Service;
+import com.example.picket.domain.images.entity.ShowImage;
+import com.example.picket.domain.images.entity.UserImage;
+import com.example.picket.domain.images.repository.ShowImageRepository;
+import com.example.picket.domain.images.repository.UserImageRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class ImageRemoveScheduler {
+
+    private final UserImageRepository userImageRepository;
+    private final ShowImageRepository showImageRepository;
+    private final S3Service s3Service;
+
+    @Scheduled(cron = "0 * * * * ?")
+    @SchedulerLock(name = "IMAGE-REMOVED-SCHEDULER", lockAtLeastFor = "PT1M", lockAtMostFor = "PT5M")
+
+    public void cleanUpRemovedImage() {
+        log.info("S3 고아객체 이미지 삭제 스케줄러 시작");
+        LocalDateTime dayBefore = LocalDateTime.now().minusDays(1);
+        deleteRemovedUserImages(dayBefore);
+        deleteRemovedShowImages(dayBefore);
+        log.info("S3 고아객체 이미지 삭제 스케줄러 완료");
+    }
+
+    private void deleteRemovedUserImages(LocalDateTime dayBefore) {
+        List<UserImage> userImagesToRemove = userImageRepository.findByUserIdIsNullAndCreatedAtBefore(dayBefore);
+        for (UserImage image : userImagesToRemove) {
+            try {
+                s3Service.delete(image.getImageUrl());
+            } catch (Exception e) {
+                log.error("S3에서 유저 프로필 이미지 삭제 실패: {}, 오류: {}", image.getImageUrl(), e.getMessage());
+            }
+        }
+        userImageRepository.deleteByUserIdIsNullAndCreatedAtBefore(dayBefore);
+        log.info("{}개의 유저 프로필 이미지가 S3에서 삭제되었습니다.", userImagesToRemove.size());
+    }
+
+    private void deleteRemovedShowImages(LocalDateTime dayBefore) {
+        List<ShowImage> removedShowImages = showImageRepository.findByShowIdIsNullAndCreatedAtBefore(dayBefore);
+        for (ShowImage image : removedShowImages) {
+            try {
+                s3Service.delete(image.getImageUrl());
+            } catch (Exception e) {
+                log.error("S3에서 공연 포스터 이미지 삭제 실패: {}, 오류: {}", image.getImageUrl(), e.getMessage());
+            }
+        }
+        showImageRepository.deleteByShowIdIsNullAndCreatedAtBefore(dayBefore);
+        log.info("{}개의 공연 포스터 이미지가 S3에서 삭제되었습니다.", removedShowImages.size());
+    }
+
+}

--- a/src/main/java/com/example/picket/common/scheduler/ImageRemoveScheduler.java
+++ b/src/main/java/com/example/picket/common/scheduler/ImageRemoveScheduler.java
@@ -5,14 +5,15 @@ import com.example.picket.domain.images.entity.ShowImage;
 import com.example.picket.domain.images.entity.UserImage;
 import com.example.picket.domain.images.repository.ShowImageRepository;
 import com.example.picket.domain.images.repository.UserImageRepository;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/example/picket/common/service/S3Service.java
+++ b/src/main/java/com/example/picket/common/service/S3Service.java
@@ -1,0 +1,143 @@
+package com.example.picket.common.service;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import com.example.picket.common.enums.ImageStatus;
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.images.dto.response.ImageResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.imgscalr.Scalr;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private static final List<String> ALLOWED_CONTENT_TYPES = Arrays.asList(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/gif",
+            "image/webp"
+    );
+    private static final long MAX_FILE_SIZE = 8 * 1024 * 1024;
+    private static final String FIXED_CONTENT_TYPE = "image/jpeg";
+    private static final int TARGET_WIDTH = 300;
+    private static final int TARGET_HEIGHT = 400;
+
+    private final S3Client s3Client;
+
+    @Getter
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public ImageResponse upload(HttpServletRequest request, long contentLength,
+                                String contentType) {
+        // 이미지 확장자 검증
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase())) {
+            throw new CustomException(BAD_REQUEST, "지원되지 않는 파일 형식입니다. 허용 Content-Type: " + ALLOWED_CONTENT_TYPES);
+        }
+
+        // 파일 크기 검증
+        if (contentLength > MAX_FILE_SIZE) {
+            throw new CustomException(BAD_REQUEST,
+                    "파일 크기가 8MB를 초과했습니다. 최대 크기: " + MAX_FILE_SIZE / (1024 * 1024) + "MB");
+        }
+
+        // 고유한 파일 이름 생성
+        String key = "images/" + UUID.randomUUID();
+        String outputFormat = contentType.substring(contentType.lastIndexOf("/") + 1);
+        System.out.println(contentType);
+        System.out.println(outputFormat);
+
+        try (InputStream inputStream = request.getInputStream()) {
+            // 이미지를 리사이징하고 JPEG로 변환
+            byte[] resizedImageBytes = resizeAndConvertToJpeg(inputStream, outputFormat);
+
+            // 리사이징된 이미지 크기
+            long resizedContentLength = resizedImageBytes.length;
+
+            // S3 업로드 요청 생성
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(contentType)
+                    .contentLength(resizedContentLength)
+                    .build();
+
+            // InputStream을 사용하여 S3에 업로드
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(resizedImageBytes));
+            log.info("파일 업로드 성공: bucket={}, key={}", bucket, key);
+            return ImageResponse.toDto(getPublicUrl(key), contentType, ImageStatus.PENDING);
+        } catch (IOException e) {
+            log.error("파일 업로드 실패: bucket={}, key={}, cause={}", bucket, key, e.getMessage(), e);
+            throw new CustomException(INTERNAL_SERVER_ERROR, "파일 업로드 중 서버 오류가 발생했습니다: " + e.getMessage());
+        } catch (SdkServiceException e) {
+            log.error("파일 업로드 실패: bucket={}, key={}, cause={}", bucket, key, e.getMessage(), e);
+            throw new CustomException(INTERNAL_SERVER_ERROR, "S3 업로드 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    public void delete(String imageUrl) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(imageUrl)
+                    .build();
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("파일 삭제 성공: bucket={}, key={}", bucket, imageUrl);
+        } catch (SdkServiceException e) {
+            log.error("파일 삭제 실패: bucket={}, key={}, cause={}", bucket, imageUrl, e.getMessage(), e);
+            throw new CustomException(INTERNAL_SERVER_ERROR, "파일 삭제 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    private String getPublicUrl(String fileName) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
+    }
+
+    private byte[] resizeAndConvertToJpeg(InputStream inputStream, String outputFormat) throws IOException {
+        // InputStream을 BufferedImage로 변환
+        BufferedImage originalImage = ImageIO.read(inputStream);
+
+        // 이미지를 300x400으로 리사이징
+        BufferedImage resizedImage = Scalr.resize(originalImage,
+                Scalr.Method.QUALITY,
+                Scalr.Mode.FIT_TO_WIDTH,
+                TARGET_WIDTH,
+                TARGET_HEIGHT,
+                Scalr.OP_ANTIALIAS);
+
+        // BufferedImage를 JPEG로 변환
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            ImageIO.write(resizedImage, outputFormat, baos);
+            return baos.toByteArray();
+        } finally {
+            // 메모리 해제
+            originalImage.flush();
+            resizedImage.flush();
+        }
+    }
+}

--- a/src/main/java/com/example/picket/common/service/S3Service.java
+++ b/src/main/java/com/example/picket/common/service/S3Service.java
@@ -3,7 +3,6 @@ package com.example.picket.common.service;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
-import com.example.picket.common.enums.ImageStatus;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.images.dto.response.ImageResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -87,7 +86,7 @@ public class S3Service {
             // InputStream을 사용하여 S3에 업로드
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(resizedImageBytes));
             log.info("파일 업로드 성공: bucket={}, key={}", bucket, key);
-            return ImageResponse.toDto(getPublicUrl(key), contentType, ImageStatus.PENDING);
+            return ImageResponse.toDto(getPublicUrl(key), contentType);
         } catch (IOException e) {
             log.error("파일 업로드 실패: bucket={}, key={}, cause={}", bucket, key, e.getMessage(), e);
             throw new CustomException(INTERNAL_SERVER_ERROR, "파일 업로드 중 서버 오류가 발생했습니다: " + e.getMessage());

--- a/src/main/java/com/example/picket/common/service/S3Service.java
+++ b/src/main/java/com/example/picket/common/service/S3Service.java
@@ -1,19 +1,8 @@
 package com.example.picket.common.service;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.images.dto.response.ImageResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-import javax.imageio.ImageIO;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +14,18 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @Service
@@ -86,7 +87,7 @@ public class S3Service {
             // InputStream을 사용하여 S3에 업로드
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(resizedImageBytes));
             log.info("파일 업로드 성공: bucket={}, key={}", bucket, key);
-            return ImageResponse.toDto(getPublicUrl(key), contentType);
+            return ImageResponse.of(getPublicUrl(key), contentType);
         } catch (IOException e) {
             log.error("파일 업로드 실패: bucket={}, key={}, cause={}", bucket, key, e.getMessage(), e);
             throw new CustomException(INTERNAL_SERVER_ERROR, "파일 업로드 중 서버 오류가 발생했습니다: " + e.getMessage());

--- a/src/main/java/com/example/picket/common/service/S3Service.java
+++ b/src/main/java/com/example/picket/common/service/S3Service.java
@@ -40,7 +40,6 @@ public class S3Service {
             "image/webp"
     );
     private static final long MAX_FILE_SIZE = 8 * 1024 * 1024;
-    private static final String FIXED_CONTENT_TYPE = "image/jpeg";
     private static final int TARGET_WIDTH = 300;
     private static final int TARGET_HEIGHT = 400;
 
@@ -69,8 +68,6 @@ public class S3Service {
         // 고유한 파일 이름 생성
         String key = "images/" + UUID.randomUUID();
         String outputFormat = contentType.substring(contentType.lastIndexOf("/") + 1);
-        System.out.println(contentType);
-        System.out.println(outputFormat);
 
         try (InputStream inputStream = request.getInputStream()) {
             // 이미지를 리사이징하고 JPEG로 변환

--- a/src/main/java/com/example/picket/config/S3Config.java
+++ b/src/main/java/com/example/picket/config/S3Config.java
@@ -1,0 +1,30 @@
+package com.example.picket.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
@@ -56,7 +56,7 @@ public class AuthController {
     public ResponseEntity<SigninResponse> signin(HttpSession session, HttpServletResponse response,
                                                  @Valid @RequestBody SigninRequest request) {
         User user = authService.signin(session, response, request.getEmail(), request.getPassword());
-        SigninResponse signinResponse = SigninResponse.toDto(user.getNickname());
+        SigninResponse signinResponse = SigninResponse.of(user.getNickname());
         return ResponseEntity.ok(signinResponse);
     }
 

--- a/src/main/java/com/example/picket/domain/auth/controller/OAuthController.java
+++ b/src/main/java/com/example/picket/domain/auth/controller/OAuthController.java
@@ -26,33 +26,33 @@ public class OAuthController {
 
     @GetMapping("/auth/session")
     public ResponseEntity<SessionResponse> getSession(@Auth AuthUser auth) {
-        if(auth == null) {
+        if (auth == null) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 
         User user = userQueryService.getUser(auth.getId());
-        return ResponseEntity.ok(SessionResponse.toDto(user.getNickname(), user.getEmail(), user.getUserRole()));
+        return ResponseEntity.ok(SessionResponse.of(user.getNickname(), user.getEmail(), user.getUserRole()));
     }
 
     @GetMapping("/auth/callback/user")
     public ResponseEntity<OAuthSigninResponse> googleUserSignin(@RequestParam("code") String code, HttpSession session) {
 
         User user = oAuthService.getOrCreateUser(session, code, UserRole.USER);
-        return ResponseEntity.ok(OAuthSigninResponse.toDto(user.getNickname(), user.getNickname() == null));
+        return ResponseEntity.ok(OAuthSigninResponse.of(user.getNickname(), user.getNickname() == null));
     }
 
     @GetMapping("/auth/callback/admin")
     public ResponseEntity<OAuthSigninResponse> googleAdminSignin(@RequestParam("code") String code, HttpSession session) {
 
         User user = oAuthService.getOrCreateUser(session, code, UserRole.ADMIN);
-        return ResponseEntity.ok(OAuthSigninResponse.toDto(user.getNickname(), user.getNickname() == null));
+        return ResponseEntity.ok(OAuthSigninResponse.of(user.getNickname(), user.getNickname() == null));
     }
 
     @GetMapping("/auth/callback/director")
     public ResponseEntity<OAuthSigninResponse> googleDirectorSignin(@RequestParam("code") String code, HttpSession session) {
 
         User user = oAuthService.getOrCreateUser(session, code, UserRole.DIRECTOR);
-        return ResponseEntity.ok(OAuthSigninResponse.toDto(user.getNickname(), user.getNickname() == null));
+        return ResponseEntity.ok(OAuthSigninResponse.of(user.getNickname(), user.getNickname() == null));
     }
 
     @PostMapping("/auth/signup")

--- a/src/main/java/com/example/picket/domain/auth/dto/response/OAuthSigninResponse.java
+++ b/src/main/java/com/example/picket/domain/auth/dto/response/OAuthSigninResponse.java
@@ -13,7 +13,7 @@ public class OAuthSigninResponse {
         this.isNewUser = isNewUser;
     }
 
-    public static OAuthSigninResponse toDto(String nickname, Boolean isNewUser) {
+    public static OAuthSigninResponse of(String nickname, Boolean isNewUser) {
         return new OAuthSigninResponse(nickname, isNewUser);
     }
 }

--- a/src/main/java/com/example/picket/domain/auth/dto/response/SessionResponse.java
+++ b/src/main/java/com/example/picket/domain/auth/dto/response/SessionResponse.java
@@ -16,7 +16,7 @@ public class SessionResponse {
         this.role = role;
     }
 
-    public static SessionResponse toDto(String nickname, String email, UserRole role) {
+    public static SessionResponse of(String nickname, String email, UserRole role) {
         return new SessionResponse(nickname, email, role);
     }
 }

--- a/src/main/java/com/example/picket/domain/auth/dto/response/SigninResponse.java
+++ b/src/main/java/com/example/picket/domain/auth/dto/response/SigninResponse.java
@@ -11,7 +11,7 @@ public class SigninResponse {
         this.nickname = nickname;
     }
 
-    public static SigninResponse toDto(String nickname) {
+    public static SigninResponse of(String nickname) {
         return new SigninResponse(nickname);
     }
 }

--- a/src/main/java/com/example/picket/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/picket/domain/auth/service/AuthService.java
@@ -1,9 +1,5 @@
 package com.example.picket.domain.auth.service;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
-
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.UserRole;
@@ -14,10 +10,13 @@ import com.example.picket.domain.user.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
 @Service
@@ -34,7 +33,7 @@ public class AuthService {
             throw new CustomException(BAD_REQUEST, "이미 가입되어있는 이메일 입니다.");
         }
 
-        User newUser = User.toEntity(email, passwordEncoder.encode(password), userRole, null, nickname, birth, gender);
+        User newUser = User.create(email, passwordEncoder.encode(password), userRole, null, nickname, birth, gender);
 
         userRepository.save(newUser);
     }
@@ -47,7 +46,7 @@ public class AuthService {
             throw new CustomException(UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
         }
 
-        AuthUser authUser = AuthUser.toEntity(user.getId(), user.getUserRole());
+        AuthUser authUser = AuthUser.create(user.getId(), user.getUserRole());
         session.setAttribute("authUser", authUser);
 
         Cookie sessionCookie = new Cookie("JSESSIONID", session.getId());

--- a/src/main/java/com/example/picket/domain/auth/service/OAuthService.java
+++ b/src/main/java/com/example/picket/domain/auth/service/OAuthService.java
@@ -29,14 +29,14 @@ public class OAuthService {
         String accessToken = googleOauthClient.getAccessToken(code, userRole);
         OAuthUser oauthUser = googleOauthClient.getUser(accessToken);
         User user = userQueryService.getUserByEmail(oauthUser.getEmail())
-                .orElseGet( () -> userRepository.save(
-                        User.toOAuthEntity(oauthUser.getEmail(),
+                .orElseGet(() -> userRepository.save(
+                        User.createWithOAuth(oauthUser.getEmail(),
                                 userRole,
                                 oauthUser.getId(),
                                 OAuth.GOOGLE
-                                )));
+                        )));
 
-        AuthUser authUser = AuthUser.toEntity(user.getId(), user.getUserRole());
+        AuthUser authUser = AuthUser.create(user.getId(), user.getUserRole());
         session.setAttribute("authUser", authUser);
         return user;
     }

--- a/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
@@ -6,7 +6,6 @@ import com.example.picket.domain.booking.dto.request.BookingRequest;
 import com.example.picket.domain.booking.dto.request.CancelBookingRequest;
 import com.example.picket.domain.booking.dto.response.CancelBookingResponse;
 import com.example.picket.domain.booking.service.BookingFacade;
-import com.example.picket.domain.booking.service.BookingService;
 import com.example.picket.domain.order.dto.response.OrderResponse;
 import com.example.picket.domain.order.entity.Order;
 import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
@@ -19,7 +18,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 @Controller
 @RequestMapping("/api/v2/")
@@ -36,9 +34,9 @@ public class BookingController {
             @PathVariable Long showDateId,
             @Auth AuthUser authUser,
             @RequestBody BookingRequest dto
-            ) throws InterruptedException {
+    ) throws InterruptedException {
         Order order = bookingFacade.booking(showId, showDateId, authUser.getId(), dto.getSeatIds());
-        OrderResponse orderResponse = OrderResponse.toDto(order);
+        OrderResponse orderResponse = OrderResponse.of(order);
         return ResponseEntity.ok(orderResponse);
     }
 
@@ -51,8 +49,8 @@ public class BookingController {
             @RequestBody CancelBookingRequest dto
     ) throws InterruptedException {
         List<Ticket> canceledTickets = bookingFacade.cancelBooking(showId, showDateId, authUser.getId(), dto.getTicketIds());
-        List<GetTicketResponse> getTicketResponses = canceledTickets.stream().map(GetTicketResponse::toDto).toList();
-        CancelBookingResponse cancelBookingResponse = CancelBookingResponse.toDto(getTicketResponses);
+        List<GetTicketResponse> getTicketResponses = canceledTickets.stream().map(GetTicketResponse::of).toList();
+        CancelBookingResponse cancelBookingResponse = CancelBookingResponse.of(getTicketResponses);
         return ResponseEntity.ok(cancelBookingResponse);
     }
 }

--- a/src/main/java/com/example/picket/domain/booking/dto/response/CancelBookingResponse.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/response/CancelBookingResponse.java
@@ -1,10 +1,8 @@
 package com.example.picket.domain.booking.dto.response;
 
 import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
-import com.example.picket.domain.ticket.entity.Ticket;
 import lombok.Getter;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -16,7 +14,7 @@ public class CancelBookingResponse {
         this.cancelledTickets = cancelledTickets;
     }
 
-    public static CancelBookingResponse toDto(List<GetTicketResponse> cancelledTickets) {
+    public static CancelBookingResponse of(List<GetTicketResponse> cancelledTickets) {
         return new CancelBookingResponse(cancelledTickets);
     }
 }

--- a/src/main/java/com/example/picket/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/picket/domain/comment/controller/CommentController.java
@@ -11,21 +11,15 @@ import com.example.picket.domain.comment.service.CommentQueryService;
 import com.example.picket.domain.ticket.service.TicketQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -48,7 +42,7 @@ public class CommentController {
                 .hasValidTicket(List.of(comment.getUser().getId()), showId)
                 .contains(comment.getUser().getId());
 
-        return ResponseEntity.ok(CommentResponse.toDto(comment, hasTicket));
+        return ResponseEntity.ok(CommentResponse.of(comment, hasTicket));
     }
 
     @Operation(summary = "댓글 수정", description = "댓글을 수정할 수 있습니다.")
@@ -63,7 +57,7 @@ public class CommentController {
                 .hasValidTicket(List.of(comment.getUser().getId()), showId)
                 .contains(comment.getUser().getId());
 
-        return ResponseEntity.ok(CommentResponse.toDto(comment, hasTicket));
+        return ResponseEntity.ok(CommentResponse.of(comment, hasTicket));
     }
 
     @Operation(summary = "댓글 삭제", description = "댓글을 삭제할 수 있습니다.")
@@ -87,7 +81,7 @@ public class CommentController {
 
         List<Long> validTicketUserIds = ticketQueryService.hasValidTicket(userIds, showId);
 
-        return ResponseEntity.ok(PageCommentResponse.toDto(comments, comment ->
+        return ResponseEntity.ok(PageCommentResponse.of(comments, comment ->
                 validTicketUserIds.contains(comment.getUser().getId())));
     }
 

--- a/src/main/java/com/example/picket/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/example/picket/domain/comment/dto/response/CommentResponse.java
@@ -33,7 +33,7 @@ public class CommentResponse {
     }
 
 
-    public static CommentResponse toDto(Comment comment, Boolean isTicketBuyer) {
+    public static CommentResponse of(Comment comment, Boolean isTicketBuyer) {
         return new CommentResponse(comment.getUser().getId()
                 , comment.getUser().getNickname()
                 , comment.getId()

--- a/src/main/java/com/example/picket/domain/comment/dto/response/PageCommentResponse.java
+++ b/src/main/java/com/example/picket/domain/comment/dto/response/PageCommentResponse.java
@@ -18,7 +18,7 @@ public class PageCommentResponse {
     private final boolean last;
 
     public PageCommentResponse(List<CommentResponse> content, int page, int size,
-                                long totalElements, int totalPages, boolean last) {
+                               long totalElements, int totalPages, boolean last) {
         this.content = content;
         this.page = page;
         this.size = size;
@@ -27,9 +27,9 @@ public class PageCommentResponse {
         this.last = last;
     }
 
-    public static PageCommentResponse toDto(Page<Comment> comments, Function<Comment, Boolean> ticketChecker) {
+    public static PageCommentResponse of(Page<Comment> comments, Function<Comment, Boolean> ticketChecker) {
         List<CommentResponse> responseList = comments.getContent().stream()
-                .map(comment -> CommentResponse.toDto(comment, ticketChecker.apply(comment)))
+                .map(comment -> CommentResponse.of(comment, ticketChecker.apply(comment)))
                 .toList();
 
         return new PageCommentResponse(

--- a/src/main/java/com/example/picket/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/picket/domain/comment/entity/Comment.java
@@ -35,7 +35,7 @@ public class Comment extends BaseEntity {
         this.user = user;
     }
 
-    public static Comment toEntity(String content,  Show show, User user) {
+    public static Comment create(String content, Show show, User user) {
         return new Comment(content, show, user);
     }
 

--- a/src/main/java/com/example/picket/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/example/picket/domain/comment/service/CommentCommandService.java
@@ -1,18 +1,19 @@
 package com.example.picket.domain.comment.service;
 
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.comment.dto.request.CommentRequest;
 import com.example.picket.domain.comment.entity.Comment;
 import com.example.picket.domain.comment.repository.CommentRepository;
 import com.example.picket.domain.show.service.ShowQueryService;
 import com.example.picket.domain.user.service.UserQueryService;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +26,7 @@ public class CommentCommandService {
     @Transactional
     public Comment createComment(Long userId, Long showId, CommentRequest commentRequest) {
 
-        return commentRepository.save(Comment.toEntity(commentRequest.getContent()
+        return commentRepository.save(Comment.create(commentRequest.getContent()
                 , showQueryService.getShow(showId)
                 , userQueryService.getUser(userId))
         );

--- a/src/main/java/com/example/picket/domain/images/dto/response/ImageResponse.java
+++ b/src/main/java/com/example/picket/domain/images/dto/response/ImageResponse.java
@@ -1,22 +1,19 @@
 package com.example.picket.domain.images.dto.response;
 
-import com.example.picket.common.enums.ImageStatus;
 import lombok.Getter;
 
 @Getter
 public class ImageResponse {
     private final String imageUrl;
     private final String fileFormat;
-    private final ImageStatus imageStatus;
 
-    private ImageResponse(String imageUrl, String fileFormat, ImageStatus imageStatus) {
+    private ImageResponse(String imageUrl, String fileFormat) {
         this.imageUrl = imageUrl;
         this.fileFormat = fileFormat;
-        this.imageStatus = imageStatus;
     }
 
-    public static ImageResponse toDto(String imageUrl, String fileFormat, ImageStatus imageStatus) {
-        return new ImageResponse(imageUrl, fileFormat, imageStatus);
+    public static ImageResponse toDto(String imageUrl, String fileFormat) {
+        return new ImageResponse(imageUrl, fileFormat);
     }
 
 }

--- a/src/main/java/com/example/picket/domain/images/dto/response/ImageResponse.java
+++ b/src/main/java/com/example/picket/domain/images/dto/response/ImageResponse.java
@@ -1,0 +1,22 @@
+package com.example.picket.domain.images.dto.response;
+
+import com.example.picket.common.enums.ImageStatus;
+import lombok.Getter;
+
+@Getter
+public class ImageResponse {
+    private final String imageUrl;
+    private final String fileFormat;
+    private final ImageStatus imageStatus;
+
+    private ImageResponse(String imageUrl, String fileFormat, ImageStatus imageStatus) {
+        this.imageUrl = imageUrl;
+        this.fileFormat = fileFormat;
+        this.imageStatus = imageStatus;
+    }
+
+    public static ImageResponse toDto(String imageUrl, String fileFormat, ImageStatus imageStatus) {
+        return new ImageResponse(imageUrl, fileFormat, imageStatus);
+    }
+
+}

--- a/src/main/java/com/example/picket/domain/images/dto/response/ImageResponse.java
+++ b/src/main/java/com/example/picket/domain/images/dto/response/ImageResponse.java
@@ -12,7 +12,7 @@ public class ImageResponse {
         this.fileFormat = fileFormat;
     }
 
-    public static ImageResponse toDto(String imageUrl, String fileFormat) {
+    public static ImageResponse of(String imageUrl, String fileFormat) {
         return new ImageResponse(imageUrl, fileFormat);
     }
 

--- a/src/main/java/com/example/picket/domain/images/entity/ShowImage.java
+++ b/src/main/java/com/example/picket/domain/images/entity/ShowImage.java
@@ -1,0 +1,58 @@
+package com.example.picket.domain.images.entity;
+
+import com.example.picket.common.entity.BaseEntity;
+import com.example.picket.common.enums.ImageStatus;
+import com.example.picket.domain.images.dto.response.ImageResponse;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "show_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ShowImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private String fileFormat;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ImageStatus imageStatus;
+
+    @Column
+    private Long showId;
+
+    private ShowImage(String imageUrl, String fileFormat, ImageStatus imageStatus, Long showId) {
+        this.imageUrl = imageUrl;
+        this.fileFormat = fileFormat;
+        this.imageStatus = imageStatus;
+        this.showId = showId;
+    }
+
+    public static ShowImage toEntity(ImageResponse imageResponse,
+                                     Long showId) {
+        return new ShowImage(imageResponse.getImageUrl(), imageResponse.getFileFormat(), imageResponse.getImageStatus(),
+                showId);
+    }
+
+    public void updateShow(Long showId) {
+        this.showId = showId;
+        this.imageStatus = ImageStatus.CREATED;
+    }
+}

--- a/src/main/java/com/example/picket/domain/images/entity/ShowImage.java
+++ b/src/main/java/com/example/picket/domain/images/entity/ShowImage.java
@@ -1,12 +1,9 @@
 package com.example.picket.domain.images.entity;
 
 import com.example.picket.common.entity.BaseEntity;
-import com.example.picket.common.enums.ImageStatus;
 import com.example.picket.domain.images.dto.response.ImageResponse;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,28 +28,22 @@ public class ShowImage extends BaseEntity {
     @Column(nullable = false)
     private String fileFormat;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ImageStatus imageStatus;
-
     @Column
     private Long showId;
 
-    private ShowImage(String imageUrl, String fileFormat, ImageStatus imageStatus, Long showId) {
+    private ShowImage(String imageUrl, String fileFormat, Long showId) {
         this.imageUrl = imageUrl;
         this.fileFormat = fileFormat;
-        this.imageStatus = imageStatus;
         this.showId = showId;
     }
 
     public static ShowImage toEntity(ImageResponse imageResponse,
                                      Long showId) {
-        return new ShowImage(imageResponse.getImageUrl(), imageResponse.getFileFormat(), imageResponse.getImageStatus(),
-                showId);
+        return new ShowImage(imageResponse.getImageUrl(), imageResponse.getFileFormat(), showId);
     }
 
     public void updateShow(Long showId) {
         this.showId = showId;
-        this.imageStatus = ImageStatus.CREATED;
     }
+
 }

--- a/src/main/java/com/example/picket/domain/images/entity/ShowImage.java
+++ b/src/main/java/com/example/picket/domain/images/entity/ShowImage.java
@@ -2,12 +2,7 @@ package com.example.picket.domain.images.entity;
 
 import com.example.picket.common.entity.BaseEntity;
 import com.example.picket.domain.images.dto.response.ImageResponse;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,8 +32,8 @@ public class ShowImage extends BaseEntity {
         this.showId = showId;
     }
 
-    public static ShowImage toEntity(ImageResponse imageResponse,
-                                     Long showId) {
+    public static ShowImage create(ImageResponse imageResponse,
+                                   Long showId) {
         return new ShowImage(imageResponse.getImageUrl(), imageResponse.getFileFormat(), showId);
     }
 

--- a/src/main/java/com/example/picket/domain/images/entity/UserImage.java
+++ b/src/main/java/com/example/picket/domain/images/entity/UserImage.java
@@ -1,0 +1,57 @@
+package com.example.picket.domain.images.entity;
+
+import com.example.picket.common.entity.BaseEntity;
+import com.example.picket.common.enums.ImageStatus;
+import com.example.picket.domain.images.dto.response.ImageResponse;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private String fileFormat;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ImageStatus imageStatus;
+
+    @Column
+    private Long userId;
+
+    private UserImage(String imageUrl, String fileFormat, ImageStatus imageStatus, Long userId) {
+        this.imageUrl = imageUrl;
+        this.fileFormat = fileFormat;
+        this.imageStatus = imageStatus;
+        this.userId = userId;
+    }
+
+    public static UserImage toEntity(ImageResponse imageResponse, Long userId) {
+        return new UserImage(imageResponse.getImageUrl(), imageResponse.getFileFormat(), imageResponse.getImageStatus(),
+                userId);
+    }
+
+    public void updateUser(Long userId) {
+        this.userId = userId;
+        this.imageStatus = ImageStatus.CREATED;
+    }
+}

--- a/src/main/java/com/example/picket/domain/images/entity/UserImage.java
+++ b/src/main/java/com/example/picket/domain/images/entity/UserImage.java
@@ -1,12 +1,9 @@
 package com.example.picket.domain.images.entity;
 
 import com.example.picket.common.entity.BaseEntity;
-import com.example.picket.common.enums.ImageStatus;
 import com.example.picket.domain.images.dto.response.ImageResponse;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,27 +28,21 @@ public class UserImage extends BaseEntity {
     @Column(nullable = false)
     private String fileFormat;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ImageStatus imageStatus;
-
     @Column
     private Long userId;
 
-    private UserImage(String imageUrl, String fileFormat, ImageStatus imageStatus, Long userId) {
+    private UserImage(String imageUrl, String fileFormat, Long userId) {
         this.imageUrl = imageUrl;
         this.fileFormat = fileFormat;
-        this.imageStatus = imageStatus;
         this.userId = userId;
     }
 
     public static UserImage toEntity(ImageResponse imageResponse, Long userId) {
-        return new UserImage(imageResponse.getImageUrl(), imageResponse.getFileFormat(), imageResponse.getImageStatus(),
-                userId);
+        return new UserImage(imageResponse.getImageUrl(), imageResponse.getFileFormat(), userId);
     }
 
     public void updateUser(Long userId) {
         this.userId = userId;
-        this.imageStatus = ImageStatus.CREATED;
     }
+
 }

--- a/src/main/java/com/example/picket/domain/images/entity/UserImage.java
+++ b/src/main/java/com/example/picket/domain/images/entity/UserImage.java
@@ -2,12 +2,7 @@ package com.example.picket.domain.images.entity;
 
 import com.example.picket.common.entity.BaseEntity;
 import com.example.picket.domain.images.dto.response.ImageResponse;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,7 +32,7 @@ public class UserImage extends BaseEntity {
         this.userId = userId;
     }
 
-    public static UserImage toEntity(ImageResponse imageResponse, Long userId) {
+    public static UserImage create(ImageResponse imageResponse, Long userId) {
         return new UserImage(imageResponse.getImageUrl(), imageResponse.getFileFormat(), userId);
     }
 

--- a/src/main/java/com/example/picket/domain/images/repository/ShowImageRepository.java
+++ b/src/main/java/com/example/picket/domain/images/repository/ShowImageRepository.java
@@ -1,0 +1,10 @@
+package com.example.picket.domain.images.repository;
+
+import com.example.picket.domain.images.entity.ShowImage;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShowImageRepository extends JpaRepository<ShowImage, Long> {
+
+    Optional<ShowImage> findByImageUrl(String imageUrl);
+}

--- a/src/main/java/com/example/picket/domain/images/repository/ShowImageRepository.java
+++ b/src/main/java/com/example/picket/domain/images/repository/ShowImageRepository.java
@@ -1,10 +1,20 @@
 package com.example.picket.domain.images.repository;
 
 import com.example.picket.domain.images.entity.ShowImage;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ShowImageRepository extends JpaRepository<ShowImage, Long> {
 
     Optional<ShowImage> findByImageUrl(String imageUrl);
+
+    List<ShowImage> findByShowIdIsNullAndCreatedAtBefore(LocalDateTime dayBefore);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ShowImage si WHERE si.showId IS NULL AND si.createdAt < :dayBefore")
+    void deleteByShowIdIsNullAndCreatedAtBefore(LocalDateTime dayBefore);
 }

--- a/src/main/java/com/example/picket/domain/images/repository/UserImageRepository.java
+++ b/src/main/java/com/example/picket/domain/images/repository/UserImageRepository.java
@@ -1,10 +1,20 @@
 package com.example.picket.domain.images.repository;
 
 import com.example.picket.domain.images.entity.UserImage;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserImageRepository extends JpaRepository<UserImage, Long> {
 
     Optional<UserImage> findByImageUrl(String profileUrl);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM UserImage ui WHERE ui.userId IS NULL AND ui.createdAt < :dayBefore")
+    void deleteByUserIdIsNullAndCreatedAtBefore(LocalDateTime dayBefore);
+
+    List<UserImage> findByUserIdIsNullAndCreatedAtBefore(LocalDateTime dayBefore);
 }

--- a/src/main/java/com/example/picket/domain/images/repository/UserImageRepository.java
+++ b/src/main/java/com/example/picket/domain/images/repository/UserImageRepository.java
@@ -1,0 +1,10 @@
+package com.example.picket.domain.images.repository;
+
+import com.example.picket.domain.images.entity.UserImage;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserImageRepository extends JpaRepository<UserImage, Long> {
+
+    Optional<UserImage> findByImageUrl(String profileUrl);
+}

--- a/src/main/java/com/example/picket/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/picket/domain/like/controller/LikeController.java
@@ -9,7 +9,6 @@ import com.example.picket.domain.like.service.LikeQueryService;
 import com.example.picket.domain.show.entity.Show;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -17,13 +16,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -42,7 +37,7 @@ public class LikeController {
         List<Show> shows = likeQueryService.getLikes(authUser.getId(), page, size);
         Pageable pageable = PageRequest.of(page, size);
         List<LikeResponse> likeResponses = shows.stream().map(
-                show -> LikeResponse.toDto(
+                show -> LikeResponse.of(
                         show.getId(),
                         show.getTitle(),
                         show.getCategory(),
@@ -50,7 +45,7 @@ public class LikeController {
                 )
         ).toList();
         Page<LikeResponse> responses = new PageImpl<>(likeResponses, pageable, likeResponses.size());
-        return ResponseEntity.ok(PageResponse.toDto(responses));
+        return ResponseEntity.ok(PageResponse.of(responses));
     }
 
     @Operation(summary = "좋아요 추가", description = "특정 공연에 좋아요를 추가할 수 있습니다.")

--- a/src/main/java/com/example/picket/domain/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/example/picket/domain/like/dto/response/LikeResponse.java
@@ -18,7 +18,7 @@ public class LikeResponse {
         this.description = description;
     }
 
-    public static LikeResponse toDto(Long showId, String showTitle, Category category, String description) {
+    public static LikeResponse of(Long showId, String showTitle, Category category, String description) {
         return new LikeResponse(showId, showTitle, category, description);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/entity/Like.java
+++ b/src/main/java/com/example/picket/domain/like/entity/Like.java
@@ -3,14 +3,7 @@ package com.example.picket.domain.like.entity;
 import com.example.picket.common.entity.BaseEntity;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.user.entity.User;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,7 +31,7 @@ public class Like extends BaseEntity {
         this.user = user;
     }
 
-    public static Like toEntity(Show show, User user) {
+    public static Like create(Show show, User user) {
         return new Like(show, user);
     }
 }

--- a/src/main/java/com/example/picket/domain/like/service/LikeCommandService.java
+++ b/src/main/java/com/example/picket/domain/like/service/LikeCommandService.java
@@ -1,8 +1,5 @@
 package com.example.picket.domain.like.service;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.like.entity.Like;
 import com.example.picket.domain.like.repository.LikeRepository;
@@ -10,10 +7,14 @@ import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.show.service.ShowQueryService;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserQueryService;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -33,7 +34,7 @@ public class LikeCommandService {
             throw new CustomException(BAD_REQUEST, "이미 해당 좋아요를 눌렀습니다.");
         }
 
-        Like like = Like.toEntity(show, user);
+        Like like = Like.create(show, user);
 
         likeRepository.save(like);
     }

--- a/src/main/java/com/example/picket/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/picket/domain/order/controller/OrderController.java
@@ -5,9 +5,7 @@ import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.dto.PageResponse;
 import com.example.picket.domain.order.dto.response.OrderResponse;
 import com.example.picket.domain.order.entity.Order;
-import com.example.picket.domain.order.repository.OrderRepository;
 import com.example.picket.domain.order.service.OrderQueryService;
-import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +16,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -35,7 +31,7 @@ public class OrderController {
             @PathVariable Long orderId,
             @Auth AuthUser authUser) {
         Order order = orderQueryService.getOrder(authUser.getId(), orderId);
-        OrderResponse orderResponse = OrderResponse.toDto(order);
+        OrderResponse orderResponse = OrderResponse.of(order);
         return ResponseEntity.ok(orderResponse);
     }
 
@@ -46,8 +42,8 @@ public class OrderController {
             @RequestParam(defaultValue = "1") int page,
             @Auth AuthUser authUser
     ) {
-        Page<OrderResponse> orderResponse = orderQueryService.getOrders(size, page, authUser.getId()).map(OrderResponse::toDto);
-        PageResponse<OrderResponse> pageOrderResponse = PageResponse.toDto(orderResponse);
+        Page<OrderResponse> orderResponse = orderQueryService.getOrders(size, page, authUser.getId()).map(OrderResponse::of);
+        PageResponse<OrderResponse> pageOrderResponse = PageResponse.of(orderResponse);
         return ResponseEntity.ok(pageOrderResponse);
     }
 }

--- a/src/main/java/com/example/picket/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/picket/domain/order/dto/response/OrderResponse.java
@@ -2,11 +2,9 @@ package com.example.picket.domain.order.dto.response;
 
 import com.example.picket.domain.order.entity.Order;
 import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
-import com.example.picket.domain.ticket.entity.Ticket;
 import lombok.Getter;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -24,10 +22,10 @@ public class OrderResponse {
         this.id = order.getId();
         this.userId = order.getUser().getId();
         this.totalPrice = order.getTotalPrice();
-        this.tickets = order.getTicket().stream().map(GetTicketResponse::toDto).toList();
+        this.tickets = order.getTicket().stream().map(GetTicketResponse::of).toList();
     }
 
-    public static OrderResponse toDto(Order order) {
+    public static OrderResponse of(Order order) {
         return new OrderResponse(order);
     }
 

--- a/src/main/java/com/example/picket/domain/order/entity/Order.java
+++ b/src/main/java/com/example/picket/domain/order/entity/Order.java
@@ -47,8 +47,8 @@ public class Order extends BaseEntity {
         this.ticket = ticket;
     }
 
-    public static Order toEntity(User user, BigDecimal totalPrice, OrderStatus orderStatus, List<Ticket> tickets) {
-        Order order =  new Order(user, totalPrice,orderStatus, tickets);
+    public static Order create(User user, BigDecimal totalPrice, OrderStatus orderStatus, List<Ticket> tickets) {
+        Order order = new Order(user, totalPrice, orderStatus, tickets);
         for (Ticket ticket : tickets) {
             ticket.setOrder(order);
         }

--- a/src/main/java/com/example/picket/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/example/picket/domain/order/service/OrderCommandService.java
@@ -23,7 +23,7 @@ public class OrderCommandService {
         BigDecimal totalPrice = tickets.stream()
                 .map(Ticket::getPrice)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        Order order = Order.toEntity(user, totalPrice, OrderStatus.ORDER_COMPLETE, tickets);
+        Order order = Order.create(user, totalPrice, OrderStatus.ORDER_COMPLETE, tickets);
         orderRepository.save(order);
         return order;
     }

--- a/src/main/java/com/example/picket/domain/ranking/dto/response/HotShowResponse.java
+++ b/src/main/java/com/example/picket/domain/ranking/dto/response/HotShowResponse.java
@@ -22,7 +22,7 @@ public class HotShowResponse {
         this.createdAt = createdAt;
     }
 
-    public static HotShowResponse toDto(HotShow hotShow) {
+    public static HotShowResponse of(HotShow hotShow) {
         return new HotShowResponse(hotShow.getShowId(), hotShow.getTitle(), hotShow.getViewCount(), hotShow.getStatus(), hotShow.getCreatedAt());
     }
 }

--- a/src/main/java/com/example/picket/domain/ranking/dto/response/LikeShowResponse.java
+++ b/src/main/java/com/example/picket/domain/ranking/dto/response/LikeShowResponse.java
@@ -22,7 +22,7 @@ public class LikeShowResponse {
         this.createdAt = createdAt;
     }
 
-    public static LikeShowResponse toDto(LikeShow likeShow) {
+    public static LikeShowResponse of(LikeShow likeShow) {
         return new LikeShowResponse(likeShow.getShowId(), likeShow.getTitle(), likeShow.getLikeCount(), likeShow.getStatus(), likeShow.getCreatedAt());
     }
 }

--- a/src/main/java/com/example/picket/domain/ranking/dto/response/PopularKeywordResponse.java
+++ b/src/main/java/com/example/picket/domain/ranking/dto/response/PopularKeywordResponse.java
@@ -18,7 +18,7 @@ public class PopularKeywordResponse {
         this.createdAt = createdAt;
     }
 
-    public static PopularKeywordResponse toDto(PopularKeyword popularKeyword) {
+    public static PopularKeywordResponse of(PopularKeyword popularKeyword) {
         return new PopularKeywordResponse(popularKeyword.getCategory(), popularKeyword.getKeywordCount(), popularKeyword.getCreatedAt());
     }
 }

--- a/src/main/java/com/example/picket/domain/ranking/entity/HotShow.java
+++ b/src/main/java/com/example/picket/domain/ranking/entity/HotShow.java
@@ -23,7 +23,7 @@ public class HotShow {
         this.createdAt = createdAt;
     }
 
-    public static HotShow toEntity(Long showId, String title, int viewCount, ShowStatus status, LocalDateTime createdAt) {
+    public static HotShow create(Long showId, String title, int viewCount, ShowStatus status, LocalDateTime createdAt) {
         return new HotShow(showId, title, viewCount, status, createdAt);
     }
 }

--- a/src/main/java/com/example/picket/domain/ranking/entity/LikeShow.java
+++ b/src/main/java/com/example/picket/domain/ranking/entity/LikeShow.java
@@ -23,7 +23,7 @@ public class LikeShow {
         this.createdAt = createdAt;
     }
 
-    public static LikeShow toEntity(Long showId, String title, Long likeCount, ShowStatus status, LocalDateTime createdAt) {
+    public static LikeShow create(Long showId, String title, Long likeCount, ShowStatus status, LocalDateTime createdAt) {
         LikeShow show = new LikeShow();
         show.showId = showId;
         show.title = title;

--- a/src/main/java/com/example/picket/domain/ranking/entity/PopularKeyword.java
+++ b/src/main/java/com/example/picket/domain/ranking/entity/PopularKeyword.java
@@ -19,7 +19,7 @@ public class PopularKeyword {
         this.createdAt = createdAt;
     }
 
-    public static PopularKeyword toEntity(Category category, Long keywordCount, LocalDateTime createdAt) {
+    public static PopularKeyword create(Category category, Long keywordCount, LocalDateTime createdAt) {
         return new PopularKeyword(category, keywordCount, createdAt);
     }
 }

--- a/src/main/java/com/example/picket/domain/ranking/entity/SearchLog.java
+++ b/src/main/java/com/example/picket/domain/ranking/entity/SearchLog.java
@@ -28,7 +28,7 @@ public class SearchLog {
         this.searchedAt = LocalDateTime.now();
     }
 
-    public static SearchLog toEntity(Category category) {
+    public static SearchLog create(Category category) {
         return new SearchLog(category);
     }
 }

--- a/src/main/java/com/example/picket/domain/ranking/scheduler/HotShowRankingScheduler.java
+++ b/src/main/java/com/example/picket/domain/ranking/scheduler/HotShowRankingScheduler.java
@@ -36,7 +36,7 @@ public class HotShowRankingScheduler {
             List<Show> topShows = showRepository.findTop10ByStatusNotAndOrderByViewCountDesc(ShowStatus.FINISHED);
             log.debug("RDS에서 조회된 공연 데이터: {}", topShows);
             List<HotShow> hotShows = topShows.stream()
-                    .map(show -> HotShow.toEntity(
+                    .map(show -> HotShow.create(
                             show.getId(),
                             show.getTitle(),
                             show.getViewCount(),

--- a/src/main/java/com/example/picket/domain/ranking/scheduler/LikeRankingScheduler.java
+++ b/src/main/java/com/example/picket/domain/ranking/scheduler/LikeRankingScheduler.java
@@ -47,7 +47,7 @@ public class LikeRankingScheduler {
             log.debug("좋아요 공연 쿼리 결과: {}, 상태 필터: {}", topShows, Arrays.toString(ACTIVE_STATUSES));
 
             List<LikeShow> showList = topShows.stream()
-                    .map(row -> LikeShow.toEntity(
+                    .map(row -> LikeShow.create(
                             (Long) row[0],
                             (String) row[1],
                             (Long) row[2],

--- a/src/main/java/com/example/picket/domain/ranking/scheduler/PopularKeywordScheduler.java
+++ b/src/main/java/com/example/picket/domain/ranking/scheduler/PopularKeywordScheduler.java
@@ -36,7 +36,7 @@ public class PopularKeywordScheduler {
         if (category != null) {
             log.info("검색 키워드 증가: {}", category.name());
             redisTemplate.opsForZSet().incrementScore(SEARCH_KEYWORD_KEY, category.name(), 1);
-            searchLogRepository.save(SearchLog.toEntity(category));
+            searchLogRepository.save(SearchLog.create(category));
         } else {
             log.warn("카테고리가 null입니다.");
         }
@@ -54,7 +54,7 @@ public class PopularKeywordScheduler {
             log.debug("상위 키워드 조회: {}", topKeywords);
 
             List<PopularKeyword> keywordList = topKeywords.stream()
-                    .map(tuple -> PopularKeyword.toEntity(
+                    .map(tuple -> PopularKeyword.create(
                             Category.valueOf(tuple.getValue()),
                             tuple.getScore().longValue(),
                             now

--- a/src/main/java/com/example/picket/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/example/picket/domain/ranking/service/RankingService.java
@@ -48,7 +48,7 @@ public class RankingService {
                         .map(json -> {
                             try {
                                 PopularKeyword keyword = objectMapper.readValue(json, PopularKeyword.class);
-                                return PopularKeywordResponse.toDto(keyword);
+                                return PopularKeywordResponse.of(keyword);
                             } catch (Exception e) {
                                 log.error("검색 키워드 역직렬화 실패: {}", json, e);
                                 return null;
@@ -63,12 +63,12 @@ public class RankingService {
             log.warn("Redis 데이터 사용 불가, RDS로 폴백");
             List<Object[]> topKeywords = searchLogRepository.findTopKeywordsSince(LocalDateTime.now().minusDays(1));
             List<PopularKeywordResponse> fallbackKeywords = topKeywords.stream()
-                    .map(row -> PopularKeyword.toEntity(
+                    .map(row -> PopularKeyword.create(
                             (Category) row[0],
                             (Long) row[1],
                             LocalDateTime.now()
                     ))
-                    .map(PopularKeywordResponse::toDto)
+                    .map(PopularKeywordResponse::of)
                     .toList();
             log.info("RDS에서 {}개 검색 키워드 조회 완료", fallbackKeywords.size());
             return fallbackKeywords;
@@ -86,7 +86,7 @@ public class RankingService {
                         .map(json -> {
                             try {
                                 HotShow show = objectMapper.readValue(json, HotShow.class);
-                                return HotShowResponse.toDto(show);
+                                return HotShowResponse.of(show);
                             } catch (Exception e) {
                                 log.error("공연 역직렬화 실패: {}", json, e);
                                 return null;
@@ -105,14 +105,14 @@ public class RankingService {
                 log.warn("RDS에서 조건에 맞는 공연 데이터가 없습니다. 상태: NOT FINISHED, 정렬: viewCount DESC");
             }
             List<HotShowResponse> fallbackShows = topShows.stream()
-                    .map(show -> HotShow.toEntity(
+                    .map(show -> HotShow.create(
                             show.getId(),
                             show.getTitle(),
                             show.getViewCount(),
                             show.getStatus(),
                             LocalDateTime.now()
                     ))
-                    .map(HotShowResponse::toDto)
+                    .map(HotShowResponse::of)
                     .toList();
             log.info("RDS에서 {}개 인기 공연 조회 완료", fallbackShows.size());
             return fallbackShows;
@@ -130,7 +130,7 @@ public class RankingService {
                         .map(json -> {
                             try {
                                 LikeShow show = objectMapper.readValue(json, LikeShow.class);
-                                return LikeShowResponse.toDto(show);
+                                return LikeShowResponse.of(show);
                             } catch (Exception e) {
                                 log.error("공연 역직렬화 실패: {}", json, e);
                                 return null;
@@ -147,14 +147,14 @@ public class RankingService {
             List<Object[]> topShows = likeRepository.findTop10ShowsByLikeCountAndStatusIn(ACTIVE_STATUSES, pageable);
             log.debug("RDS 좋아요 공연 쿼리 결과: {}", topShows);
             List<LikeShowResponse> fallbackShows = topShows.stream()
-                    .map(row -> LikeShow.toEntity(
+                    .map(row -> LikeShow.create(
                             (Long) row[0],
                             (String) row[1],
                             (Long) row[2],
                             (ShowStatus) row[3],
                             LocalDateTime.now()
                     ))
-                    .map(LikeShowResponse::toDto)
+                    .map(LikeShowResponse::of)
                     .toList();
             log.info("RDS에서 {}개 좋아요 공연 조회 완료", fallbackShows.size());
             return fallbackShows;

--- a/src/main/java/com/example/picket/domain/seat/dto/request/SeatUpdateRequest.java
+++ b/src/main/java/com/example/picket/domain/seat/dto/request/SeatUpdateRequest.java
@@ -33,7 +33,7 @@ public class SeatUpdateRequest {
         this.price = price;
     }
 
-    public static SeatUpdateRequest toDto(String grade, int quantity, BigDecimal price) {
+    public static SeatUpdateRequest of(String grade, int quantity, BigDecimal price) {
         return new SeatUpdateRequest(grade, quantity, price);
     }
 }

--- a/src/main/java/com/example/picket/domain/seat/dto/response/SeatDetailResponse.java
+++ b/src/main/java/com/example/picket/domain/seat/dto/response/SeatDetailResponse.java
@@ -3,7 +3,6 @@ package com.example.picket.domain.seat.dto.response;
 import com.example.picket.common.enums.Grade;
 import com.example.picket.common.enums.SeatStatus;
 import com.example.picket.domain.seat.entity.Seat;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
@@ -21,7 +20,7 @@ public class SeatDetailResponse {
         this.status = seat.getSeatStatus();
     }
 
-    public static SeatDetailResponse toDto(Seat seat) {
+    public static SeatDetailResponse of(Seat seat) {
         return new SeatDetailResponse(seat);
     }
 

--- a/src/main/java/com/example/picket/domain/seat/dto/response/SeatGroupByGradeResponse.java
+++ b/src/main/java/com/example/picket/domain/seat/dto/response/SeatGroupByGradeResponse.java
@@ -2,9 +2,10 @@ package com.example.picket.domain.seat.dto.response;
 
 import com.example.picket.common.enums.Grade;
 import com.example.picket.domain.seat.entity.Seat;
+import lombok.Getter;
+
 import java.math.BigDecimal;
 import java.util.List;
-import lombok.Getter;
 
 @Getter
 public class SeatGroupByGradeResponse {
@@ -18,12 +19,12 @@ public class SeatGroupByGradeResponse {
         this.seats = seats;
     }
 
-    public static SeatGroupByGradeResponse toDto(Grade grade, BigDecimal price, List<Seat> seats) {
+    public static SeatGroupByGradeResponse of(Grade grade, BigDecimal price, List<Seat> seats) {
         return new SeatGroupByGradeResponse(
                 grade,
                 price,
                 seats.stream()
-                        .map(SeatDetailResponse::toDto)
+                        .map(SeatDetailResponse::of)
                         .toList()
         );
     }

--- a/src/main/java/com/example/picket/domain/seat/dto/response/SeatSummaryResponse.java
+++ b/src/main/java/com/example/picket/domain/seat/dto/response/SeatSummaryResponse.java
@@ -18,7 +18,7 @@ public class SeatSummaryResponse {
         this.available = available;
     }
 
-    public static SeatSummaryResponse toDto(Grade grade, int total, int reserved, int available) {
+    public static SeatSummaryResponse of(Grade grade, int total, int reserved, int available) {
         return new SeatSummaryResponse(grade, total, reserved, available);
     }
 

--- a/src/main/java/com/example/picket/domain/seat/entity/Seat.java
+++ b/src/main/java/com/example/picket/domain/seat/entity/Seat.java
@@ -47,7 +47,7 @@ public class Seat extends BaseEntity {
         this.showDate = showDate;
     }
 
-    public static Seat toEntity(Grade grade, int seatNumber, BigDecimal price, ShowDate showDate) {
+    public static Seat create(Grade grade, int seatNumber, BigDecimal price, ShowDate showDate) {
         return new Seat(grade, seatNumber, price, SeatStatus.AVAILABLE, showDate);
     }
 

--- a/src/main/java/com/example/picket/domain/seat/service/SeatCommandService.java
+++ b/src/main/java/com/example/picket/domain/seat/service/SeatCommandService.java
@@ -143,7 +143,7 @@ public class SeatCommandService {
                 .orElse(0); // 현재 좌석이 없으면 0을 기준으로 시작
 
         for (int i = 1; i <= toAdd; i++) {
-            Seat newSeat = Seat.toEntity(grade, nextNumber + i, price, showDate);
+            Seat newSeat = Seat.create(grade, nextNumber + i, price, showDate);
             Seat savedSeat = seatRepository.save(newSeat);
 
             result.add(savedSeat);
@@ -166,7 +166,7 @@ public class SeatCommandService {
     // 종료된 공연 검증
     private void validateEndShow(Show show) {
         boolean hasEnded = showDateQueryService.getShowDatesByShowId(show.getId()).stream()
-            .anyMatch(sd -> sd.getDate().atTime(sd.getEndTime()).isBefore(LocalDateTime.now()));
+                .anyMatch(sd -> sd.getDate().atTime(sd.getEndTime()).isBefore(LocalDateTime.now()));
 
         if (hasEnded) {
             throw new CustomException(BAD_REQUEST, "종료된 공연은 수정할 수 없습니다.");

--- a/src/main/java/com/example/picket/domain/seat/service/SeatResponseMapper.java
+++ b/src/main/java/com/example/picket/domain/seat/service/SeatResponseMapper.java
@@ -3,10 +3,11 @@ package com.example.picket.domain.seat.service;
 import com.example.picket.common.enums.Grade;
 import com.example.picket.domain.seat.dto.response.SeatGroupByGradeResponse;
 import com.example.picket.domain.seat.entity.Seat;
+import org.springframework.stereotype.Component;
+
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.stereotype.Component;
 
 @Component
 public class SeatResponseMapper {
@@ -20,7 +21,7 @@ public class SeatResponseMapper {
                     Grade grade = entry.getKey();
                     List<Seat> groupedSeats = entry.getValue();
                     BigDecimal price = groupedSeats.get(0).getPrice(); // 등급별 가격 동일
-                    return SeatGroupByGradeResponse.toDto(grade, price, groupedSeats);
+                    return SeatGroupByGradeResponse.of(grade, price, groupedSeats);
                 })
                 .toList();
     }

--- a/src/main/java/com/example/picket/domain/show/controller/ShowController.java
+++ b/src/main/java/com/example/picket/domain/show/controller/ShowController.java
@@ -18,13 +18,22 @@ import com.example.picket.domain.show.service.ShowDateQueryService;
 import com.example.picket.domain.show.service.ShowQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v2")
@@ -46,7 +55,8 @@ public class ShowController {
             @Valid @RequestBody ShowCreateRequest request
     ) {
         Show show = showCommandService.createShow(user, request);
-        List<ShowDateDetailResponse> showDateDetail = showDateQueryService.getShowDateDetailResponsesByShowId(show.getId());
+        List<ShowDateDetailResponse> showDateDetail = showDateQueryService.getShowDateDetailResponsesByShowId(
+                show.getId());
         return ResponseEntity.ok(ShowDetailResponse.toDto(show, showDateDetail));
     }
 
@@ -88,7 +98,8 @@ public class ShowController {
             @Valid @RequestBody ShowUpdateRequest request
     ) {
         Show show = showCommandService.updateShow(authUser, showId, request);
-        List<ShowDateDetailResponse> showDateDetail = showDateQueryService.getShowDateDetailResponsesByShowId(show.getId());
+        List<ShowDateDetailResponse> showDateDetail = showDateQueryService.getShowDateDetailResponsesByShowId(
+                show.getId());
         return ResponseEntity.ok(ShowDetailResponse.toDto(show, showDateDetail));
     }
 
@@ -104,4 +115,12 @@ public class ShowController {
         return ResponseEntity.noContent().build();
     }
 
+
+    @Operation(summary = "공연 포스터 이미지 업로드", description = "공연 포스터 이미지를 업로드할 수 있습니다.")
+    @PostMapping("/shows/uploadImage")
+    public ResponseEntity<String> uploadImage(HttpServletRequest request,
+                                              @RequestHeader("Content-Length") long contentLength,
+                                              @RequestHeader(value = "Content-Type", defaultValue = "application/octet-stream") String contentType) {
+        return ResponseEntity.ok(showCommandService.uploadImage(request, contentLength, contentType));
+    }
 }

--- a/src/main/java/com/example/picket/domain/show/controller/ShowController.java
+++ b/src/main/java/com/example/picket/domain/show/controller/ShowController.java
@@ -20,20 +20,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v2")
@@ -57,7 +49,7 @@ public class ShowController {
         Show show = showCommandService.createShow(user, request);
         List<ShowDateDetailResponse> showDateDetail = showDateQueryService.getShowDateDetailResponsesByShowId(
                 show.getId());
-        return ResponseEntity.ok(ShowDetailResponse.toDto(show, showDateDetail));
+        return ResponseEntity.ok(ShowDetailResponse.of(show, showDateDetail));
     }
 
     // 공연 목록 조회 API (카테고리, 정렬 지원)
@@ -74,7 +66,7 @@ public class ShowController {
         popularKeywordScheduler.incrementSearchKeyword(category);
 
         Page<ShowResponse> response = showQueryService.getShows(category, sortBy, order, page, size);
-        return ResponseEntity.ok(PageResponse.toDto(response));
+        return ResponseEntity.ok(PageResponse.of(response));
     }
 
     // 공연 단건 조회
@@ -100,7 +92,7 @@ public class ShowController {
         Show show = showCommandService.updateShow(authUser, showId, request);
         List<ShowDateDetailResponse> showDateDetail = showDateQueryService.getShowDateDetailResponsesByShowId(
                 show.getId());
-        return ResponseEntity.ok(ShowDetailResponse.toDto(show, showDateDetail));
+        return ResponseEntity.ok(ShowDetailResponse.of(show, showDateDetail));
     }
 
     // 공연 삭제 API (소프트 삭제 방식)

--- a/src/main/java/com/example/picket/domain/show/controller/ShowController.java
+++ b/src/main/java/com/example/picket/domain/show/controller/ShowController.java
@@ -115,7 +115,7 @@ public class ShowController {
         return ResponseEntity.noContent().build();
     }
 
-
+    @AuthPermission(role = UserRole.DIRECTOR)
     @Operation(summary = "공연 포스터 이미지 업로드", description = "공연 포스터 이미지를 업로드할 수 있습니다.")
     @PostMapping("/shows/uploadImage")
     public ResponseEntity<String> uploadImage(HttpServletRequest request,

--- a/src/main/java/com/example/picket/domain/show/dto/response/ShowDateDetailResponse.java
+++ b/src/main/java/com/example/picket/domain/show/dto/response/ShowDateDetailResponse.java
@@ -31,17 +31,17 @@ public class ShowDateDetailResponse {
         this.seats = seats;
     }
 
-    public static ShowDateDetailResponse toDto(Long id, LocalDate date, LocalTime startTime, LocalTime endTime, Integer totalSeatCount,
-                                               Integer reservedSeatCount, Integer availableSeatCount, List<SeatSummaryResponse> seats) {
+    public static ShowDateDetailResponse of(Long id, LocalDate date, LocalTime startTime, LocalTime endTime, Integer totalSeatCount,
+                                            Integer reservedSeatCount, Integer availableSeatCount, List<SeatSummaryResponse> seats) {
         return new ShowDateDetailResponse(
-            id,
-            date,
-            startTime,
-            endTime,
-            totalSeatCount,
-            reservedSeatCount,
-            availableSeatCount,
-            seats
+                id,
+                date,
+                startTime,
+                endTime,
+                totalSeatCount,
+                reservedSeatCount,
+                availableSeatCount,
+                seats
         );
     }
 

--- a/src/main/java/com/example/picket/domain/show/dto/response/ShowDateResponse.java
+++ b/src/main/java/com/example/picket/domain/show/dto/response/ShowDateResponse.java
@@ -27,7 +27,7 @@ public class ShowDateResponse {
         this.availableSeatCount = showDate.getAvailableSeatCount();
     }
 
-    public static ShowDateResponse toDto(ShowDate showDate) {
+    public static ShowDateResponse of(ShowDate showDate) {
         return new ShowDateResponse(showDate);
     }
 

--- a/src/main/java/com/example/picket/domain/show/dto/response/ShowDetailResponse.java
+++ b/src/main/java/com/example/picket/domain/show/dto/response/ShowDetailResponse.java
@@ -50,44 +50,44 @@ public class ShowDetailResponse {
         this.modifiedAt = modifiedAt;
     }
 
-    public static ShowDetailResponse toDto(Long id, Long directorId, String title, String posterUrl, Category category,
-                                           String description, String location, LocalDateTime reservationStart, LocalDateTime reservationEnd,
-                                           Integer ticketsLimitPerUser, int viewCount,
-                                           List<ShowDateDetailResponse> showDates, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public static ShowDetailResponse of(Long id, Long directorId, String title, String posterUrl, Category category,
+                                        String description, String location, LocalDateTime reservationStart, LocalDateTime reservationEnd,
+                                        Integer ticketsLimitPerUser, int viewCount,
+                                        List<ShowDateDetailResponse> showDates, LocalDateTime createdAt, LocalDateTime modifiedAt) {
         return new ShowDetailResponse(
-            id,
-            directorId,
-            title,
-            posterUrl,
-            category,
-            description,
-            location,
-            reservationStart,
-            reservationEnd,
-            ticketsLimitPerUser,
-            viewCount,
-            showDates,
-            createdAt,
-            modifiedAt
+                id,
+                directorId,
+                title,
+                posterUrl,
+                category,
+                description,
+                location,
+                reservationStart,
+                reservationEnd,
+                ticketsLimitPerUser,
+                viewCount,
+                showDates,
+                createdAt,
+                modifiedAt
         );
     }
 
-    public static ShowDetailResponse toDto(Show show, List<ShowDateDetailResponse> showDateDetailResponse) {
+    public static ShowDetailResponse of(Show show, List<ShowDateDetailResponse> showDateDetailResponse) {
         return new ShowDetailResponse(
-            show.getId(),
-            show.getDirectorId(),
-            show.getTitle(),
-            show.getPosterUrl(),
-            show.getCategory(),
-            show.getDescription(),
-            show.getLocation(),
-            show.getReservationStart(),
-            show.getReservationEnd(),
-            show.getTicketsLimitPerUser(),
-            show.getViewCount(),
-            showDateDetailResponse,
-            show.getCreatedAt(),
-            show.getModifiedAt()
+                show.getId(),
+                show.getDirectorId(),
+                show.getTitle(),
+                show.getPosterUrl(),
+                show.getCategory(),
+                show.getDescription(),
+                show.getLocation(),
+                show.getReservationStart(),
+                show.getReservationEnd(),
+                show.getTicketsLimitPerUser(),
+                show.getViewCount(),
+                showDateDetailResponse,
+                show.getCreatedAt(),
+                show.getModifiedAt()
         );
     }
 

--- a/src/main/java/com/example/picket/domain/show/dto/response/ShowResponse.java
+++ b/src/main/java/com/example/picket/domain/show/dto/response/ShowResponse.java
@@ -3,11 +3,12 @@ package com.example.picket.domain.show.dto.response;
 import com.example.picket.common.enums.ShowStatus;
 import com.example.picket.domain.show.entity.Show;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -38,7 +39,7 @@ public class ShowResponse {
     private ShowResponse(Long id, Long directorId, String title, String posterUrl, String category, String description,
                          String location, String reservationStart, String reservationEnd, Integer ticketsLimitPerUser, int viewCount, ShowStatus showStatus,
                          List<ShowDateResponse> showDates, LocalDateTime createdAt, LocalDateTime modifiedAt
-                         ) {
+    ) {
         this.id = id;
         this.directorId = directorId;
         this.title = title;
@@ -57,7 +58,7 @@ public class ShowResponse {
     }
 
     // 공연 + 날짜 리스트 기반 응답 객체 생성
-    public static ShowResponse toDto(Show show, List<ShowDateResponse> showDateResponses) {
+    public static ShowResponse of(Show show, List<ShowDateResponse> showDateResponses) {
         return new ShowResponse(
                 show.getId(),
                 show.getDirectorId(),

--- a/src/main/java/com/example/picket/domain/show/entity/Show.java
+++ b/src/main/java/com/example/picket/domain/show/entity/Show.java
@@ -4,20 +4,13 @@ import com.example.picket.common.entity.BaseEntity;
 import com.example.picket.common.enums.Category;
 import com.example.picket.common.enums.ShowStatus;
 import com.example.picket.domain.show.dto.request.ShowUpdateRequest;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Table(name = "shows")
@@ -87,9 +80,9 @@ public class Show extends BaseEntity {
         this.status = ShowStatus.RESERVATION_PENDING;
     }
 
-    public static Show toEntity(Long directorId, String title, String posterUrl, Category category, String description,
-                                String location, LocalDateTime reservationStart, LocalDateTime reservationEnd,
-                                Integer ticketsLimitPerUser) {
+    public static Show create(Long directorId, String title, String posterUrl, Category category, String description,
+                              String location, LocalDateTime reservationStart, LocalDateTime reservationEnd,
+                              Integer ticketsLimitPerUser) {
         return new Show(directorId, title, posterUrl, category, description, location, reservationStart, reservationEnd,
                 ticketsLimitPerUser);
     }

--- a/src/main/java/com/example/picket/domain/show/entity/ShowDate.java
+++ b/src/main/java/com/example/picket/domain/show/entity/ShowDate.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -61,8 +62,8 @@ public class ShowDate extends BaseEntity {
         this.show = show;
     }
 
-    public static ShowDate toEntity(LocalDate date, LocalTime startTime, LocalTime endTime, Integer totalSeatCount,
-                                    Integer reservedSeatCount, Show show) {
+    public static ShowDate create(LocalDate date, LocalTime startTime, LocalTime endTime, Integer totalSeatCount,
+                                  Integer reservedSeatCount, Show show) {
         return new ShowDate(date, startTime, endTime, totalSeatCount, reservedSeatCount, show);
     }
 

--- a/src/main/java/com/example/picket/domain/show/repository/querydsl/ShowQueryDslRepositoryImpl.java
+++ b/src/main/java/com/example/picket/domain/show/repository/querydsl/ShowQueryDslRepositoryImpl.java
@@ -38,13 +38,13 @@ public class ShowQueryDslRepositoryImpl implements ShowQueryDslRepository {
 
         // 1. 전체 카운트 조회
         Long totalCount = queryFactory
-            .select(show.count())
-            .from(show)
-            .where(
-                category != null ? show.category.eq(category) : null,
-                show.deletedAt.isNull()
-            )
-            .fetchOne();
+                .select(show.count())
+                .from(show)
+                .where(
+                        category != null ? show.category.eq(category) : null,
+                        show.deletedAt.isNull()
+                )
+                .fetchOne();
 
         if (totalCount == null || totalCount == 0) {
             return new PageImpl<>(List.of(), pageable, 0);
@@ -52,16 +52,16 @@ public class ShowQueryDslRepositoryImpl implements ShowQueryDslRepository {
 
         // 2. Show ID만 페이징하여 조회
         List<Long> showIds = queryFactory
-            .select(show.id)
-            .from(show)
-            .where(
-                category != null ? show.category.eq(category) : null,
-                show.deletedAt.isNull()
-            )
-            .orderBy(getOrderSpecifier(sortBy, order))
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
+                .select(show.id)
+                .from(show)
+                .where(
+                        category != null ? show.category.eq(category) : null,
+                        show.deletedAt.isNull()
+                )
+                .orderBy(getOrderSpecifier(sortBy, order))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
         if (showIds.isEmpty()) {
             return new PageImpl<>(List.of(), pageable, totalCount);
@@ -69,15 +69,15 @@ public class ShowQueryDslRepositoryImpl implements ShowQueryDslRepository {
 
         // 3. Show와 ShowDate 조회
         List<Tuple> tuples = queryFactory
-            .select(show, showDate)
-            .from(show)
-            .leftJoin(showDate).on(showDate.show.eq(show))
-            .where(
-                show.id.in(showIds),
-                show.deletedAt.isNull()
-            )
-            .orderBy(getOrderSpecifier(sortBy, order))
-            .fetch();
+                .select(show, showDate)
+                .from(show)
+                .leftJoin(showDate).on(showDate.show.eq(show))
+                .where(
+                        show.id.in(showIds),
+                        show.deletedAt.isNull()
+                )
+                .orderBy(getOrderSpecifier(sortBy, order))
+                .fetch();
 
         if (tuples.isEmpty()) {
             return new PageImpl<>(List.of(), pageable, totalCount);
@@ -85,41 +85,41 @@ public class ShowQueryDslRepositoryImpl implements ShowQueryDslRepository {
 
         // 4. Show 그룹핑
         Map<Long, List<Show>> showGroups = tuples.stream()
-            .map(tuple -> tuple.get(show))
-            .collect(Collectors.groupingBy(
-                Show::getId,
-                LinkedHashMap::new,     // 정렬 순서 보장
-                Collectors.toList()
-            ));
+                .map(tuple -> tuple.get(show))
+                .collect(Collectors.groupingBy(
+                        Show::getId,
+                        LinkedHashMap::new,     // 정렬 순서 보장
+                        Collectors.toList()
+                ));
 
         // 5. ShowDate 그룹핑
         Map<Long, List<ShowDate>> showDateGroups = tuples.stream()
-            .filter(tuple -> tuple.get(showDate) != null)
-            .collect(Collectors.groupingBy(
-                tuple -> tuple.get(showDate).getShow().getId(),
-                Collectors.mapping(tuple -> tuple.get(showDate), Collectors.toList())
-            ));
+                .filter(tuple -> tuple.get(showDate) != null)
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(showDate).getShow().getId(),
+                        Collectors.mapping(tuple -> tuple.get(showDate), Collectors.toList())
+                ));
 
         // 6. ShowResponse 생성
         List<ShowResponse> result = showGroups.entrySet().stream()
-            .map(entry -> {
-                Long showId = entry.getKey();
-                Show showEntity = entry.getValue().get(0);
+                .map(entry -> {
+                    Long showId = entry.getKey();
+                    Show showEntity = entry.getValue().get(0);
 
-                ShowResponse response = ShowResponse.toDto(
-                    showEntity,
-                    new ArrayList<>()
-                );
+                    ShowResponse response = ShowResponse.of(
+                            showEntity,
+                            new ArrayList<>()
+                    );
 
-                List<ShowDate> showDates = showDateGroups.getOrDefault(showId, List.of());
-                List<ShowDateResponse> showDateResponses = showDates.stream()
-                    .map(ShowDateResponse::toDto)
-                    .toList();
+                    List<ShowDate> showDates = showDateGroups.getOrDefault(showId, List.of());
+                    List<ShowDateResponse> showDateResponses = showDates.stream()
+                            .map(ShowDateResponse::of)
+                            .toList();
 
-                response.getShowDates().addAll(showDateResponses);
-                return response;
-            })
-            .toList();
+                    response.getShowDates().addAll(showDateResponses);
+                    return response;
+                })
+                .toList();
 
         // 7. Page 객체 반환
         Page<ShowResponse> page = new PageImpl<>(result, pageable, totalCount);
@@ -130,23 +130,23 @@ public class ShowQueryDslRepositoryImpl implements ShowQueryDslRepository {
     public Optional<ShowDetailResponse> getShowDetailResponseById(Long showId) {
 
         List<Tuple> tuples = queryFactory
-            .select(
-                show,
-                showDate.id,
-                showDate.date,
-                showDate.startTime,
-                showDate.endTime,
-                showDate.totalSeatCount,
-                showDate.reservedSeatCount,
-                showDate.availableSeatCount,
-                seat.grade,
-                seat.seatStatus
-            )
-            .from(show)
-            .leftJoin(showDate).on(showDate.show.eq(show))
-            .leftJoin(seat).on(seat.showDate.eq(showDate))
-            .where(show.id.eq(showId))
-            .fetch();
+                .select(
+                        show,
+                        showDate.id,
+                        showDate.date,
+                        showDate.startTime,
+                        showDate.endTime,
+                        showDate.totalSeatCount,
+                        showDate.reservedSeatCount,
+                        showDate.availableSeatCount,
+                        seat.grade,
+                        seat.seatStatus
+                )
+                .from(show)
+                .leftJoin(showDate).on(showDate.show.eq(show))
+                .leftJoin(seat).on(seat.showDate.eq(showDate))
+                .where(show.id.eq(showId))
+                .fetch();
 
         if (tuples.isEmpty()) {
             return Optional.empty();
@@ -154,80 +154,80 @@ public class ShowQueryDslRepositoryImpl implements ShowQueryDslRepository {
 
         // Show 정보는 첫 번째 튜플에서 추출
         Show showEntity = tuples.get(0).get(show);
-        ShowDetailResponse detailResponse = ShowDetailResponse.toDto(
-            showEntity.getId(),
-            showEntity.getDirectorId(),
-            showEntity.getTitle(),
-            showEntity.getPosterUrl(),
-            showEntity.getCategory(),
-            showEntity.getDescription(),
-            showEntity.getLocation(),
-            showEntity.getReservationStart(),
-            showEntity.getReservationEnd(),
-            showEntity.getTicketsLimitPerUser(),
-            showEntity.getViewCount(),
-            new ArrayList<>(),
-            showEntity.getCreatedAt(),
-            showEntity.getModifiedAt()
+        ShowDetailResponse detailResponse = ShowDetailResponse.of(
+                showEntity.getId(),
+                showEntity.getDirectorId(),
+                showEntity.getTitle(),
+                showEntity.getPosterUrl(),
+                showEntity.getCategory(),
+                showEntity.getDescription(),
+                showEntity.getLocation(),
+                showEntity.getReservationStart(),
+                showEntity.getReservationEnd(),
+                showEntity.getTicketsLimitPerUser(),
+                showEntity.getViewCount(),
+                new ArrayList<>(),
+                showEntity.getCreatedAt(),
+                showEntity.getModifiedAt()
         );
 
         // ShowDate별 그룹핑 및 처리
         Map<Long, List<Tuple>> showDateGroups = tuples.stream()
-            .filter(tuple -> tuple.get(showDate.id) != null)
-            .collect(Collectors.groupingBy(tuple -> tuple.get(showDate.id)));
+                .filter(tuple -> tuple.get(showDate.id) != null)
+                .collect(Collectors.groupingBy(tuple -> tuple.get(showDate.id)));
 
         List<ShowDateDetailResponse> showDateDetails = showDateGroups.entrySet().stream()
-            .map(entry -> {
-                Long dateId = entry.getKey();
-                List<Tuple> dateTuples = entry.getValue();
-                Tuple firstTuple = dateTuples.get(0);
+                .map(entry -> {
+                    Long dateId = entry.getKey();
+                    List<Tuple> dateTuples = entry.getValue();
+                    Tuple firstTuple = dateTuples.get(0);
 
-                // ShowDate 정보 추출
-                LocalDate date = firstTuple.get(showDate.date);
-                LocalTime startTime = firstTuple.get(showDate.startTime);
-                LocalTime endTime = firstTuple.get(showDate.endTime);
-                Integer totalSeatCount = firstTuple.get(showDate.totalSeatCount);
-                Integer reservedSeatCount = firstTuple.get(showDate.reservedSeatCount);
-                Integer availableSeatCount = firstTuple.get(showDate.availableSeatCount);
+                    // ShowDate 정보 추출
+                    LocalDate date = firstTuple.get(showDate.date);
+                    LocalTime startTime = firstTuple.get(showDate.startTime);
+                    LocalTime endTime = firstTuple.get(showDate.endTime);
+                    Integer totalSeatCount = firstTuple.get(showDate.totalSeatCount);
+                    Integer reservedSeatCount = firstTuple.get(showDate.reservedSeatCount);
+                    Integer availableSeatCount = firstTuple.get(showDate.availableSeatCount);
 
-                // Seat 등급별 그룹핑 및 요약
-                Map<Grade, Long> seatCountsByGrade = dateTuples.stream()
-                    .filter(tuple -> tuple.get(seat.grade) != null)
-                    .collect(Collectors.groupingBy(
-                        tuple -> tuple.get(seat.grade),
-                        Collectors.counting()
-                    ));
+                    // Seat 등급별 그룹핑 및 요약
+                    Map<Grade, Long> seatCountsByGrade = dateTuples.stream()
+                            .filter(tuple -> tuple.get(seat.grade) != null)
+                            .collect(Collectors.groupingBy(
+                                    tuple -> tuple.get(seat.grade),
+                                    Collectors.counting()
+                            ));
 
-                Map<Grade, Long> reservedCountsByGrade = dateTuples.stream()
-                    .filter(tuple -> tuple.get(seat.grade) != null && tuple.get(seat.seatStatus) == SeatStatus.RESERVED)
-                    .collect(Collectors.groupingBy(
-                        tuple -> tuple.get(seat.grade),
-                        Collectors.counting()
-                    ));
+                    Map<Grade, Long> reservedCountsByGrade = dateTuples.stream()
+                            .filter(tuple -> tuple.get(seat.grade) != null && tuple.get(seat.seatStatus) == SeatStatus.RESERVED)
+                            .collect(Collectors.groupingBy(
+                                    tuple -> tuple.get(seat.grade),
+                                    Collectors.counting()
+                            ));
 
-                List<SeatSummaryResponse> seatSummaries = seatCountsByGrade.entrySet().stream()
-                    .map(gradeEntry -> {
-                        Grade grade = gradeEntry.getKey();
-                        int total = gradeEntry.getValue().intValue();
-                        int reserved = reservedCountsByGrade.getOrDefault(grade, 0L).intValue();
-                        int available = total - reserved;
-                        return SeatSummaryResponse.toDto(grade, total, reserved, available);
-                    })
-                    .collect(Collectors.toList());
+                    List<SeatSummaryResponse> seatSummaries = seatCountsByGrade.entrySet().stream()
+                            .map(gradeEntry -> {
+                                Grade grade = gradeEntry.getKey();
+                                int total = gradeEntry.getValue().intValue();
+                                int reserved = reservedCountsByGrade.getOrDefault(grade, 0L).intValue();
+                                int available = total - reserved;
+                                return SeatSummaryResponse.of(grade, total, reserved, available);
+                            })
+                            .collect(Collectors.toList());
 
-                // ShowDateDetailResponse 생성
-                return ShowDateDetailResponse.toDto(
-                    dateId,
-                    date,
-                    startTime,
-                    endTime,
-                    totalSeatCount,
-                    reservedSeatCount,
-                    availableSeatCount,
-                    seatSummaries
-                );
-            })
-            .toList();
+                    // ShowDateDetailResponse 생성
+                    return ShowDateDetailResponse.of(
+                            dateId,
+                            date,
+                            startTime,
+                            endTime,
+                            totalSeatCount,
+                            reservedSeatCount,
+                            availableSeatCount,
+                            seatSummaries
+                    );
+                })
+                .toList();
 
         detailResponse.getShowDates().addAll(showDateDetails);
         return Optional.of(detailResponse);

--- a/src/main/java/com/example/picket/domain/show/service/ShowCommandService.java
+++ b/src/main/java/com/example/picket/domain/show/service/ShowCommandService.java
@@ -1,9 +1,5 @@
 package com.example.picket.domain.show.service;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.exception.CustomException;
@@ -22,12 +18,15 @@ import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.show.entity.ShowDate;
 import com.example.picket.domain.show.repository.ShowRepository;
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -48,7 +47,7 @@ public class ShowCommandService {
         validateShowTimes(request);
 
         // 공연 생성 및 저장
-        Show show = Show.toEntity(
+        Show show = Show.create(
                 authUser.getId(),
                 request.getTitle(),
                 request.getPosterUrl(),
@@ -72,7 +71,7 @@ public class ShowCommandService {
         for (var dateRequest : request.getDates()) {
             validateSeatCount(dateRequest); // 좌석 수 검증
 
-            ShowDate showDate = ShowDate.toEntity(
+            ShowDate showDate = ShowDate.create(
                     dateRequest.getDate(),
                     dateRequest.getStartTime(),
                     dateRequest.getEndTime(),
@@ -202,7 +201,7 @@ public class ShowCommandService {
     private void createSeatsForShowDate(ShowDate showDate, List<SeatCreateRequest> seatRequests, List<Seat> seats) {
         for (SeatCreateRequest seatRequest : seatRequests) {
             for (int i = 1; i <= seatRequest.getSeatCount(); i++) {
-                seats.add(Seat.toEntity(
+                seats.add(Seat.create(
                         seatRequest.getGrade(),
                         i,
                         seatRequest.getPrice(),
@@ -215,7 +214,7 @@ public class ShowCommandService {
     //이미지 업로드
     public String uploadImage(HttpServletRequest request, long contentLength, String contentType) {
         ImageResponse imageResponse = s3Service.upload(request, contentLength, contentType);
-        ShowImage showImage = ShowImage.toEntity(imageResponse, null);
+        ShowImage showImage = ShowImage.create(imageResponse, null);
         showImageRepository.save(showImage);
         return imageResponse.getImageUrl();
     }

--- a/src/main/java/com/example/picket/domain/show/service/ShowCommandService.java
+++ b/src/main/java/com/example/picket/domain/show/service/ShowCommandService.java
@@ -150,6 +150,8 @@ public class ShowCommandService {
             seatCommandService.deleteAll(seats);
         }
 
+        deleteShowImage(show.getPosterUrl());
+
     }
 
     // 공연 좌석 수 검증

--- a/src/main/java/com/example/picket/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/example/picket/domain/ticket/controller/TicketController.java
@@ -1,12 +1,8 @@
 package com.example.picket.domain.ticket.controller;
 
 import com.example.picket.common.annotation.Auth;
-import com.example.picket.common.annotation.AuthPermission;
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.dto.PageResponse;
-import com.example.picket.common.enums.UserRole;
-import com.example.picket.domain.ticket.dto.response.CreateTicketResponse;
-import com.example.picket.domain.ticket.dto.response.DeleteTicketResponse;
 import com.example.picket.domain.ticket.dto.response.GetTicketResponse;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.ticket.service.TicketCommandService;
@@ -19,8 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -40,7 +34,7 @@ public class TicketController {
 //            @PathVariable Long seatId,
 //            @Auth AuthUser authUser) {
 //        Ticket ticket = ticketCommandService.createTicket(authUser.getId(), authUser.getUserRole(), seatId);
-//        return ResponseEntity.ok(CreateTicketResponse.toDto(ticket));
+//        return ResponseEntity.ok(CreateTicketResponse.of(ticket));
 //    }
 
     @Operation(summary = "티켓 다건 조회", description = "티켓을 다건 조회할 수 있습니다.")
@@ -51,8 +45,8 @@ public class TicketController {
             @Auth AuthUser authUser
     ) {
         Page<GetTicketResponse> getTicketResponsePage = ticketQueryService.getTickets(authUser.getId(), size, page)
-                .map(GetTicketResponse::toDto);
-        return ResponseEntity.ok(PageResponse.toDto(getTicketResponsePage));
+                .map(GetTicketResponse::of);
+        return ResponseEntity.ok(PageResponse.of(getTicketResponsePage));
     }
 
     @Operation(summary = "티켓 단건 조회", description = "티켓을 단건 조회할 수 있습니다.")
@@ -62,7 +56,7 @@ public class TicketController {
             @Auth AuthUser authUser
     ) {
         Ticket ticket = ticketQueryService.getTicket(authUser.getId(), ticketId);
-        return ResponseEntity.ok(GetTicketResponse.toDto(ticket));
+        return ResponseEntity.ok(GetTicketResponse.of(ticket));
     }
 
 //    @Operation(summary = "티켓 삭제", description = "티켓을 삭제할 수 있습니다.")
@@ -71,6 +65,6 @@ public class TicketController {
 //            @PathVariable Long ticketId,
 //            @Auth AuthUser authUser) {
 //        Ticket ticket = ticketCommandService.deleteTicket(ticketId, authUser.getId());
-//        return ResponseEntity.ok(DeleteTicketResponse.toDto(ticket));
+//        return ResponseEntity.ok(DeleteTicketResponse.of(ticket));
 //    }
 }

--- a/src/main/java/com/example/picket/domain/ticket/dto/response/CreateTicketResponse.java
+++ b/src/main/java/com/example/picket/domain/ticket/dto/response/CreateTicketResponse.java
@@ -37,7 +37,7 @@ public class CreateTicketResponse {
         this.modifiedAt = ticket.getModifiedAt();
     }
 
-    public static CreateTicketResponse toDto(Ticket ticket) {
+    public static CreateTicketResponse of(Ticket ticket) {
         return new CreateTicketResponse(ticket);
     }
 }

--- a/src/main/java/com/example/picket/domain/ticket/dto/response/DeleteTicketResponse.java
+++ b/src/main/java/com/example/picket/domain/ticket/dto/response/DeleteTicketResponse.java
@@ -40,7 +40,7 @@ public class DeleteTicketResponse {
         this.deletedAt = ticket.getDeletedAt();
     }
 
-    public static DeleteTicketResponse toDto(Ticket ticket) {
+    public static DeleteTicketResponse of(Ticket ticket) {
         return new DeleteTicketResponse(ticket);
     }
 }

--- a/src/main/java/com/example/picket/domain/ticket/dto/response/GetTicketResponse.java
+++ b/src/main/java/com/example/picket/domain/ticket/dto/response/GetTicketResponse.java
@@ -37,7 +37,7 @@ public class GetTicketResponse {
         this.modifiedAt = ticket.getModifiedAt();
     }
 
-    public static GetTicketResponse toDto(Ticket ticket) {
+    public static GetTicketResponse of(Ticket ticket) {
         return new GetTicketResponse(ticket);
     }
 }

--- a/src/main/java/com/example/picket/domain/ticket/entity/Ticket.java
+++ b/src/main/java/com/example/picket/domain/ticket/entity/Ticket.java
@@ -62,7 +62,7 @@ public class Ticket extends BaseEntity {
         this.status = status;
     }
 
-    public static Ticket toEntity(User user, Show show, Seat seat, BigDecimal price, TicketStatus status) {
+    public static Ticket create(User user, Show show, Seat seat, BigDecimal price, TicketStatus status) {
         return new Ticket(user, show, seat, price, status);
     }
 }

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketCommandService.java
@@ -1,9 +1,5 @@
 package com.example.picket.domain.ticket.service;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 import com.example.picket.common.enums.SeatStatus;
 import com.example.picket.common.enums.TicketStatus;
 import com.example.picket.common.exception.CustomException;
@@ -13,12 +9,13 @@ import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.ticket.repository.TicketRepository;
 import com.example.picket.domain.user.entity.User;
-
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +29,7 @@ public class TicketCommandService {
         return seatIds.stream().map(seatId -> {
             Seat foundSeat = seatQueryService.getSeat(seatId);
             foundSeat.updateSeatStatus(SeatStatus.RESERVED);
-            Ticket ticket = Ticket.toEntity(user, show, foundSeat, foundSeat.getPrice(), TicketStatus.TICKET_CREATED);
+            Ticket ticket = Ticket.create(user, show, foundSeat, foundSeat.getPrice(), TicketStatus.TICKET_CREATED);
             ticketRepository.save(ticket);
             return ticket;
         }).toList();

--- a/src/main/java/com/example/picket/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/picket/domain/user/controller/UserController.java
@@ -15,14 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,7 +37,7 @@ public class UserController {
     public ResponseEntity<UserResponse> updateUser(@Auth AuthUser authUser,
                                                    @RequestBody UpdateUserRequest request) {
         User updatedUser = userService.updateUser(authUser, request);
-        return ResponseEntity.ok(UserResponse.toDto(
+        return ResponseEntity.ok(UserResponse.of(
                 updatedUser.getEmail(),
                 updatedUser.getUserRole(),
                 updatedUser.getProfileUrl(),

--- a/src/main/java/com/example/picket/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/picket/domain/user/controller/UserController.java
@@ -11,18 +11,21 @@ import com.example.picket.domain.user.service.UserCommandService;
 import com.example.picket.domain.user.service.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v2")
 @Tag(name = "유저 관리 API", description = "유저 프로필 조회, 프로필 수정, 비밀번호 수정, 유저 탈퇴 기능 API입니다.")
 public class UserController {
 
@@ -62,5 +65,13 @@ public class UserController {
     public void withdrawUser(@Auth AuthUser authUser,
                              @RequestBody WithdrawUserRequest request) {
         userService.withdrawUserRequest(authUser, request);
+    }
+
+    @Operation(summary = "유저 프로필 이미지 업로드", description = "유저 프로필 이미지 업로드 API입니다")
+    @PostMapping("/users/uploadImage")
+    public ResponseEntity<String> uploadImage(HttpServletRequest request,
+                                              @RequestHeader("Content-Length") long contentLength,
+                                              @RequestHeader(value = "Content-Type", defaultValue = "application/octet-stream") String contentType) {
+        return ResponseEntity.ok(userService.uploadImage(request, contentLength, contentType));
     }
 }

--- a/src/main/java/com/example/picket/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/picket/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserCommandService;
 import com.example.picket.domain.user.service.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -69,9 +70,12 @@ public class UserController {
 
     @Operation(summary = "유저 프로필 이미지 업로드", description = "유저 프로필 이미지 업로드 API입니다")
     @PostMapping("/users/uploadImage")
-    public ResponseEntity<String> uploadImage(HttpServletRequest request,
-                                              @RequestHeader("Content-Length") long contentLength,
-                                              @RequestHeader(value = "Content-Type", defaultValue = "application/octet-stream") String contentType) {
+    public ResponseEntity<String> uploadImage(
+            HttpServletRequest request,
+            @Parameter(description = "파일의 크기", required = true, example = "1024")
+            @RequestHeader("Content-Length") long contentLength,
+            @Parameter(description = "요청 이미지의 타입", required = true, example = "image/jpeg")
+            @RequestHeader(value = "Content-Type", defaultValue = "application/octet-stream") String contentType) {
         return ResponseEntity.ok(userService.uploadImage(request, contentLength, contentType));
     }
 }

--- a/src/main/java/com/example/picket/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/picket/domain/user/dto/response/UserResponse.java
@@ -24,7 +24,7 @@ public class UserResponse {
         this.gender = gender;
     }
 
-    public static UserResponse toDto(String email, UserRole userRole, String profileUrl, String nickname, LocalDate birth, Gender gender) {
+    public static UserResponse of(String email, UserRole userRole, String profileUrl, String nickname, LocalDate birth, Gender gender) {
         return new UserResponse(email, userRole, profileUrl, nickname, birth, gender);
     }
 }

--- a/src/main/java/com/example/picket/domain/user/entity/User.java
+++ b/src/main/java/com/example/picket/domain/user/entity/User.java
@@ -4,20 +4,12 @@ import com.example.picket.common.entity.BaseEntity;
 import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.OAuth;
 import com.example.picket.common.enums.UserRole;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import java.time.LocalDate;
-import java.util.UUID;
-
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "users")
@@ -78,12 +70,12 @@ public class User extends BaseEntity {
 
     }
 
-    public static User toEntity(String email, String password, UserRole userRole, String profileUrl, String nickname,
-                                LocalDate birth, Gender gender) {
+    public static User create(String email, String password, UserRole userRole, String profileUrl, String nickname,
+                              LocalDate birth, Gender gender) {
         return new User(email, password, userRole, profileUrl, nickname, birth, gender);
     }
 
-    public static User toOAuthEntity(String email, UserRole userRole, String oauthId, OAuth oauthProvider) {
+    public static User createWithOAuth(String email, UserRole userRole, String oauthId, OAuth oauthProvider) {
         return new User(email, userRole, oauthId, oauthProvider);
     }
 

--- a/src/main/java/com/example/picket/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/picket/domain/user/service/UserCommandService.java
@@ -5,24 +5,31 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.exception.CustomException;
+import com.example.picket.common.service.S3Service;
 import com.example.picket.config.PasswordEncoder;
+import com.example.picket.domain.images.dto.response.ImageResponse;
+import com.example.picket.domain.images.entity.UserImage;
+import com.example.picket.domain.images.repository.UserImageRepository;
 import com.example.picket.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.picket.domain.user.dto.request.UpdateUserRequest;
 import com.example.picket.domain.user.dto.request.WithdrawUserRequest;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserCommandService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final S3Service s3Service;
+    private final UserImageRepository userImageRepository;
 
-    @Transactional
     public User updateUser(AuthUser authUser, UpdateUserRequest request) {
         User user = userRepository.findById(authUser.getId()).orElseThrow(
                 () -> new CustomException(NOT_FOUND, "해당 유저를 찾을 수 없습니다.")
@@ -32,12 +39,20 @@ public class UserCommandService {
             throw new CustomException(UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
         }
 
+        UserImage userImage = userImageRepository.findByImageUrl(request.getProfileUrl())
+                .orElseThrow(() -> new CustomException(NOT_FOUND, "해당 이미지를 찾을 수 없습니다. 다시 업로드 시도를 해주세요."));
+        userImage.updateUser(user.getId());
+
+        if (user.getProfileUrl() != null) {
+            deleteUserImage(user.getProfileUrl());
+            s3Service.delete(user.getProfileUrl());
+        }
+
         user.update(request.getNickname(), request.getProfileUrl());
 
         return user;
     }
 
-    @Transactional
     public void updatePassword(AuthUser authUser, UpdatePasswordRequest request) {
         User user = userRepository.findById(authUser.getId()).orElseThrow(
                 () -> new CustomException(NOT_FOUND, "해당 유저를 찾을 수 없습니다.")
@@ -52,7 +67,6 @@ public class UserCommandService {
         user.passwordUpdate(encodePassword);
     }
 
-    @Transactional
     public void withdrawUserRequest(AuthUser authUser, WithdrawUserRequest request) {
         User user = userRepository.findById(authUser.getId()).orElseThrow(
                 () -> new CustomException(NOT_FOUND, "해당 유저를 찾을 수 없습니다.")
@@ -63,5 +77,19 @@ public class UserCommandService {
         }
 
         userRepository.delete(user);
+    }
+
+    public String uploadImage(HttpServletRequest request, long contentLength, String contentType) {
+
+        ImageResponse imageResponse = s3Service.upload(request, contentLength, contentType);
+        UserImage userImage = UserImage.toEntity(imageResponse, null);
+        userImageRepository.save(userImage);
+        return imageResponse.getImageUrl();
+    }
+
+    public void deleteUserImage(String imageUrl) {
+        UserImage userImage = userImageRepository.findByImageUrl(imageUrl)
+                .orElseThrow(() -> new CustomException(NOT_FOUND, "해당 이미지 파일을 찾을 수 없습니다."));
+        userImageRepository.delete(userImage);
     }
 }

--- a/src/main/java/com/example/picket/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/picket/domain/user/service/UserCommandService.java
@@ -1,8 +1,5 @@
 package com.example.picket.domain.user.service;
 
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
-
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.common.service.S3Service;
@@ -19,6 +16,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -83,7 +83,7 @@ public class UserCommandService {
     public String uploadImage(HttpServletRequest request, long contentLength, String contentType) {
 
         ImageResponse imageResponse = s3Service.upload(request, contentLength, contentType);
-        UserImage userImage = UserImage.toEntity(imageResponse, null);
+        UserImage userImage = UserImage.create(imageResponse, null);
         userImageRepository.save(userImage);
         return imageResponse.getImageUrl();
     }

--- a/src/main/java/com/example/picket/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/picket/domain/user/service/UserCommandService.java
@@ -76,6 +76,7 @@ public class UserCommandService {
             throw new CustomException(UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
         }
 
+        deleteUserImage(user.getProfileUrl());
         userRepository.delete(user);
     }
 

--- a/src/main/java/com/example/picket/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/example/picket/domain/user/service/UserQueryService.java
@@ -1,7 +1,5 @@
 package com.example.picket.domain.user.service;
 
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.user.dto.response.UserResponse;
@@ -12,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +26,7 @@ public class UserQueryService {
                 () -> new CustomException(NOT_FOUND, "해당 유저를 찾을 수 없습니다.")
         );
 
-        return UserResponse.toDto(user.getEmail(), user.getUserRole(), user.getProfileUrl(), user.getNickname(),
+        return UserResponse.of(user.getEmail(), user.getUserRole(), user.getProfileUrl(), user.getNickname(),
                 user.getBirth(), user.getGender());
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,7 +26,7 @@ oauth:
   google:
     client-id: ${CLIENT_ID}
     client-secret: ${CLIENT_SECRET_KEY}
-    redirect-uris :
+    redirect-uris:
       director: http://localhost:8080/api/v2/auth/callback/director
       user: http://localhost:8080/api/v2/auth/callback/user
       admin: http://localhost:8080/api/v2/auth/callback/admin

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,3 +38,15 @@ oauth:
       admin: https://www.thepickets.com/api/v2/auth/callback/admin
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
+    s3:
+      bucket: ${AWS_S3_IMAGE_BUCKET}
+    region:
+      static: ${AWS_REGION}
+    stack:
+      auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ oauth:
   google:
     client-id: ${CLIENT_ID}
     client-secret: ${CLIENT_SECRET_KEY}
-    redirect-uris :
+    redirect-uris:
       director: http://localhost:8080/api/v2/auth/callback/director
       user: http://localhost:8080/api/v2/auth/callback/user
       admin: http://localhost:8080/api/v2/auth/callback/admin
@@ -43,3 +43,15 @@ server:
   tomcat:
     mbeanregistry:
       enabled: true
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
+    s3:
+      bucket: ${AWS_S3_IMAGE_BUCKET}
+    region:
+      static: ${AWS_REGION}
+    stack:
+      auto: false

--- a/src/test/java/com/example/picket/common/service/S3ServiceTest.java
+++ b/src/test/java/com/example/picket/common/service/S3ServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.example.picket.common.enums.ImageStatus;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.images.dto.response.ImageResponse;
 import jakarta.servlet.ServletInputStream;
@@ -153,7 +152,6 @@ class S3ServiceTest {
             assertThat(imageResponse.getImageUrl()).startsWith(
                     String.format("https://null.s3.null.amazonaws.com/images/"));
             assertThat(imageResponse.getFileFormat()).isEqualTo(VALID_CONTENT_TYPE);
-            assertThat(imageResponse.getImageStatus()).isEqualTo(ImageStatus.PENDING);
             verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
             verify(spyRequest, times(1)).getInputStream();
         }

--- a/src/test/java/com/example/picket/common/service/S3ServiceTest.java
+++ b/src/test/java/com/example/picket/common/service/S3ServiceTest.java
@@ -1,0 +1,194 @@
+package com.example.picket.common.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.picket.common.enums.ImageStatus;
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.images.dto.response.ImageResponse;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.DelegatingServletInputStream;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+    @Mock
+    S3Client s3Client;
+
+    @Mock
+    HttpServletRequest request;
+
+    @InjectMocks
+    S3Service s3Service;
+
+    private static final long VALID_CONTENT_LENGTH = 1024L;
+    private static final String VALID_CONTENT_TYPE = "image/jpeg";
+    private static final long MAX_FILE_SIZE = 8 * 1024 * 1024;
+    private static final List<String> ALLOWED_CONTENT_TYPES = Arrays.asList(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/gif",
+            "image/webp"
+    );
+
+    @Nested
+    class 이미지_업로드_테스트 {
+
+        @Test
+        void 이미지_업로드_시_확장자가_null일_경우_실패() {
+            // given
+            long contentLength = 1234L;
+            String contentType = null;
+
+            // when & then
+            assertThatThrownBy(() -> s3Service.upload(request, contentLength, contentType))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("지원되지 않는 파일 형식입니다. 허용 Content-Type: " + ALLOWED_CONTENT_TYPES);
+        }
+
+        @Test
+        void 이미지_업로드_시_확장자가_지원되는_타입이_아닐_경우_실패() {
+            // given
+            long contentLength = 1234L;
+            String contentType = "image/asdf";
+
+            // when & then
+            assertThatThrownBy(() -> s3Service.upload(request, contentLength, contentType))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("지원되지 않는 파일 형식입니다. 허용 Content-Type: " + ALLOWED_CONTENT_TYPES);
+        }
+
+        @Test
+        void 이미지_업로드_시_파일_크기가_8MB보다_클_경우_실패() {
+            // given
+            long contentLength = 9 * 1024 * 1024;
+
+            // when & then
+            assertThatThrownBy(() -> s3Service.upload(request, contentLength, VALID_CONTENT_TYPE))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("파일 크기가 8MB를 초과했습니다. 최대 크기: " + MAX_FILE_SIZE / (1024 * 1024) + "MB");
+        }
+
+        @Test
+        void 이미지_업로드_시_파일_업로드_중_SdkServiceException_발생할_경우_실패() throws IOException {
+            // given
+            BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(image, "jpeg", baos);
+            byte[] imageBytes = baos.toByteArray();
+
+            HttpServletRequest spyRequest = Mockito.spy(HttpServletRequest.class);
+            ServletInputStream servletInputStream = new DelegatingServletInputStream(
+                    new ByteArrayInputStream(imageBytes));
+            doReturn(servletInputStream).when(spyRequest).getInputStream();
+
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenThrow(SdkServiceException.builder().message("S3 upload failed").build());
+
+            // when & then
+            assertThatThrownBy(() -> s3Service.upload(spyRequest, imageBytes.length, VALID_CONTENT_TYPE))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("S3 업로드 중 오류가 발생했습니다");
+            verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+            verify(spyRequest, times(1)).getInputStream();
+        }
+
+        @Test
+        void 이미지_업로드_시_파일_업로드_중_IOException_발생할_경우_실패() throws IOException {
+            // given
+            when(request.getInputStream()).thenThrow(new IOException("Input stream error"));
+
+            // when & then
+            assertThatThrownBy(() -> s3Service.upload(request, VALID_CONTENT_LENGTH, VALID_CONTENT_TYPE))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("파일 업로드 중 서버 오류가 발생했습니다: Input stream error");
+        }
+
+        @Test
+        void 이미지_업로드_성공() throws IOException {
+            // given
+            BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(image, "jpeg", baos);
+            byte[] imageBytes = baos.toByteArray();
+
+            HttpServletRequest spyRequest = Mockito.spy(HttpServletRequest.class);
+            ServletInputStream servletInputStream = new DelegatingServletInputStream(
+                    new ByteArrayInputStream(imageBytes));
+            doReturn(servletInputStream).when(spyRequest).getInputStream();
+
+            // when
+            ImageResponse imageResponse = s3Service.upload(spyRequest, imageBytes.length, VALID_CONTENT_TYPE);
+
+            // then
+            assertThat(imageResponse).isNotNull();
+            assertThat(imageResponse.getImageUrl()).startsWith(
+                    String.format("https://null.s3.null.amazonaws.com/images/"));
+            assertThat(imageResponse.getFileFormat()).isEqualTo(VALID_CONTENT_TYPE);
+            assertThat(imageResponse.getImageStatus()).isEqualTo(ImageStatus.PENDING);
+            verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+            verify(spyRequest, times(1)).getInputStream();
+        }
+
+    }
+
+    @Nested
+    class 이미지_삭제_테스트 {
+
+        @Test
+        void 이미지_삭제_시_파일_삭제_중_SdkServiceException_발생할_경우_실패() {
+            // given
+            String imageUrl = "images/test-image.jpg";
+            doThrow(SdkServiceException.builder().message("S3 delete failed").build())
+                    .when(s3Client).deleteObject(any(DeleteObjectRequest.class));
+
+            // when & then
+            assertThatThrownBy(() -> s3Service.delete(imageUrl))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("파일 삭제 중 오류가 발생했습니다");
+            verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        void 이미지_삭제_성공() {
+            // given
+            String imageUrl = "images/test-image.jpg";
+            when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenReturn(any(DeleteObjectResponse.class));
+
+            // when
+            s3Service.delete(imageUrl);
+
+            // then
+            verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+    }
+}

--- a/src/test/java/com/example/picket/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/picket/domain/auth/service/AuthServiceTest.java
@@ -1,14 +1,5 @@
 package com.example.picket.domain.auth.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.UserRole;
@@ -18,8 +9,6 @@ import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +16,18 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -112,7 +113,7 @@ class AuthServiceTest {
             LocalDate birth = LocalDate.of(2000, 12, 12);
             Gender gender = Gender.MALE;
             UserRole userRole = UserRole.USER;
-            User user = User.toEntity(email, notMatchPassword, userRole, null, nickname, birth, gender);
+            User user = User.create(email, notMatchPassword, userRole, null, nickname, birth, gender);
             given(userRepository.findByEmail(any())).willReturn(Optional.of(user));
             given(passwordEncoder.matches(any(), any())).willReturn(false);
             // when & then
@@ -131,7 +132,7 @@ class AuthServiceTest {
             LocalDate birth = LocalDate.of(2000, 12, 12);
             Gender gender = Gender.MALE;
             UserRole userRole = UserRole.USER;
-            User user = User.toEntity(email, password, userRole, null, nickname, birth, gender);
+            User user = User.create(email, password, userRole, null, nickname, birth, gender);
             given(userRepository.findByEmail(any())).willReturn(Optional.of(user));
             given(passwordEncoder.matches(any(), any())).willReturn(true);
 

--- a/src/test/java/com/example/picket/domain/auth/service/OAuthServiceTest.java
+++ b/src/test/java/com/example/picket/domain/auth/service/OAuthServiceTest.java
@@ -51,8 +51,8 @@ class OAuthServiceTest {
         String oAuthId = "google-12345";
         UserRole role = UserRole.USER;
 
-        OAuthUser oauthUser = OAuthUser.toEntity(oAuthId, email);
-        User user = User.toOAuthEntity(email, role, oAuthId, OAuth.GOOGLE);
+        OAuthUser oauthUser = OAuthUser.create(oAuthId, email);
+        User user = User.createWithOAuth(email, role, oAuthId, OAuth.GOOGLE);
         ReflectionTestUtils.setField(user, "id", 1L);
 
         given(googleOauthClient.getAccessToken(anyString(), any(UserRole.class))).willReturn(accessToken);
@@ -76,8 +76,8 @@ class OAuthServiceTest {
         String oAuthId = "new-google-54321";
         UserRole role = UserRole.USER;
 
-        OAuthUser oauthUser = OAuthUser.toEntity(oAuthId, email);
-        User newUser = User.toOAuthEntity(email, role, oAuthId, OAuth.GOOGLE);
+        OAuthUser oauthUser = OAuthUser.create(oAuthId, email);
+        User newUser = User.createWithOAuth(email, role, oAuthId, OAuth.GOOGLE);
         ReflectionTestUtils.setField(newUser, "id", 100L);
 
         given(googleOauthClient.getAccessToken(anyString(), any(UserRole.class))).willReturn(accessToken);
@@ -102,7 +102,7 @@ class OAuthServiceTest {
         LocalDate birth = LocalDate.of(2000, 1, 1);
         Gender gender = Gender.FEMALE;
 
-        User newUser = User.toOAuthEntity("user@example.com" , UserRole.USER ,oAuthId ,OAuth.GOOGLE);
+        User newUser = User.createWithOAuth("user@example.com", UserRole.USER, oAuthId, OAuth.GOOGLE);
         ReflectionTestUtils.setField(newUser, "id", userId);
         given(userQueryService.getUser(anyLong())).willReturn(newUser);
 

--- a/src/test/java/com/example/picket/domain/comment/service/CommentCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/comment/service/CommentCommandServiceTest.java
@@ -1,14 +1,9 @@
 package com.example.picket.domain.comment.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
-import com.example.picket.common.enums.*;
+import com.example.picket.common.enums.Category;
+import com.example.picket.common.enums.Gender;
+import com.example.picket.common.enums.Grade;
+import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.comment.dto.request.CommentRequest;
 import com.example.picket.domain.comment.entity.Comment;
@@ -19,17 +14,24 @@ import com.example.picket.domain.show.entity.ShowDate;
 import com.example.picket.domain.show.service.ShowQueryService;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserQueryService;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @ExtendWith(MockitoExtension.class)
 class CommentCommandServiceTest {
@@ -69,7 +71,7 @@ class CommentCommandServiceTest {
     }
 
     @Test
-    void 댓글_생성_완료(){
+    void 댓글_생성_완료() {
         // given
         Long userId = 1L;
         User user = createUser(userId);
@@ -96,7 +98,7 @@ class CommentCommandServiceTest {
     }
 
     @Test
-    void 댓글_수정시_유저정보가_일치하지_않을경우_오류발생(){
+    void 댓글_수정시_유저정보가_일치하지_않을경우_오류발생() {
         // given
         Long writeId = 1L;
         User WriteUser = createUser(writeId);
@@ -109,7 +111,7 @@ class CommentCommandServiceTest {
 
         Long commentId = 1L;
         CommentRequest commentRequest = new CommentRequest("댓글내용");
-        Comment comment = Comment.toEntity(commentRequest.getContent(), show, WriteUser);
+        Comment comment = Comment.create(commentRequest.getContent(), show, WriteUser);
         ReflectionTestUtils.setField(comment, "id", commentId);
 
         // when
@@ -122,7 +124,7 @@ class CommentCommandServiceTest {
     }
 
     @Test
-    void 댓글_수정_완료(){
+    void 댓글_수정_완료() {
         // given
         Long userId = 1L;
         User user = createUser(userId);
@@ -132,7 +134,7 @@ class CommentCommandServiceTest {
 
         Long commentId = 1L;
         CommentRequest commentRequest = new CommentRequest("댓글내용");
-        Comment comment = Comment.toEntity(commentRequest.getContent(), show, user);
+        Comment comment = Comment.create(commentRequest.getContent(), show, user);
         ReflectionTestUtils.setField(comment, "id", commentId);
 
         given(commentRepository.findByIdAndShowIdAndUserId(anyLong(), anyLong(), anyLong())).willReturn(Optional.of(comment));
@@ -146,7 +148,7 @@ class CommentCommandServiceTest {
     }
 
     @Test
-    void 댓글_삭제_권한이_없는_경우_오류_발생(){
+    void 댓글_삭제_권한이_없는_경우_오류_발생() {
         // given
         Long writeId = 1L;
         User WriteUser = createUser(writeId);
@@ -159,7 +161,7 @@ class CommentCommandServiceTest {
 
         Long commentId = 1L;
         CommentRequest commentRequest = new CommentRequest("댓글내용");
-        Comment comment = Comment.toEntity(commentRequest.getContent(), show, WriteUser);
+        Comment comment = Comment.create(commentRequest.getContent(), show, WriteUser);
         ReflectionTestUtils.setField(comment, "id", commentId);
 
         given(commentRepository.findByIdAndShowId(anyLong(), anyLong())).willReturn(Optional.of(comment));
@@ -174,7 +176,7 @@ class CommentCommandServiceTest {
     }
 
     @Test
-    void 댓글_작성자가_삭제_성공(){
+    void 댓글_작성자가_삭제_성공() {
         // given
         Long userId = 1L;
         User user = createUser(userId);
@@ -184,7 +186,7 @@ class CommentCommandServiceTest {
 
         Long commentId = 1L;
         CommentRequest commentRequest = new CommentRequest("댓글내용");
-        Comment comment = Comment.toEntity(commentRequest.getContent(), show, user);
+        Comment comment = Comment.create(commentRequest.getContent(), show, user);
         ReflectionTestUtils.setField(comment, "id", commentId);
 
         given(commentRepository.findByIdAndShowId(anyLong(), anyLong())).willReturn(Optional.of(comment));
@@ -197,7 +199,7 @@ class CommentCommandServiceTest {
     }
 
     @Test
-    void 공연_생성자가_삭제_성공(){
+    void 공연_생성자가_삭제_성공() {
         // given
         Long userId = 1L;
         User user = createUser(userId);
@@ -210,7 +212,7 @@ class CommentCommandServiceTest {
 
         Long commentId = 1L;
         CommentRequest commentRequest = new CommentRequest("댓글내용");
-        Comment comment = Comment.toEntity(commentRequest.getContent(), show, user);
+        Comment comment = Comment.create(commentRequest.getContent(), show, user);
         ReflectionTestUtils.setField(comment, "id", commentId);
 
         given(commentRepository.findByIdAndShowId(anyLong(), anyLong())).willReturn(Optional.of(comment));
@@ -223,11 +225,11 @@ class CommentCommandServiceTest {
 
 
     private User createUser(Long userId) {
-        User user = User.toEntity("user@example.com"
-                ,"test123!"
+        User user = User.create("user@example.com"
+                , "test123!"
                 , UserRole.USER
-                ,null
-                ,"닉네임"
+                , null
+                , "닉네임"
                 , LocalDate.parse("1990-06-25")
                 , Gender.FEMALE);
 
@@ -237,11 +239,11 @@ class CommentCommandServiceTest {
     }
 
     private User createDirectorUser(Long userId) {
-        User user = User.toEntity("director@example.com"
-                ,"test123!"
+        User user = User.create("director@example.com"
+                , "test123!"
                 , UserRole.DIRECTOR
-                ,null
-                ,"닉네임"
+                , null
+                , "닉네임"
                 , LocalDate.parse("1990-06-25")
                 , Gender.FEMALE);
 
@@ -251,8 +253,8 @@ class CommentCommandServiceTest {
     }
 
     private Show createShow(User user, Long showId) {
-        Show show = Show.toEntity(user.getId()
-                ,"제목"
+        Show show = Show.create(user.getId()
+                , "제목"
                 , "포스터url"
                 , Category.CLASSIC
                 , "description"
@@ -269,7 +271,7 @@ class CommentCommandServiceTest {
     }
 
     private ShowDate createShowDate(Show show, Long showDateId) {
-        ShowDate showDate = ShowDate.toEntity(LocalDate.now()
+        ShowDate showDate = ShowDate.create(LocalDate.now()
                 , LocalTime.now()
                 , LocalTime.now().plusHours(1)
                 , 10
@@ -282,7 +284,7 @@ class CommentCommandServiceTest {
     }
 
     private Seat createSeat(ShowDate showDate, Long seatId) {
-        Seat seat = Seat.toEntity(Grade.A
+        Seat seat = Seat.create(Grade.A
                 , 1
                 , new BigDecimal(100000)
                 , showDate);

--- a/src/test/java/com/example/picket/domain/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/comment/service/CommentQueryServiceTest.java
@@ -1,6 +1,9 @@
 package com.example.picket.domain.comment.service;
 
-import com.example.picket.common.enums.*;
+import com.example.picket.common.enums.Category;
+import com.example.picket.common.enums.Gender;
+import com.example.picket.common.enums.Grade;
+import com.example.picket.common.enums.UserRole;
 import com.example.picket.domain.comment.entity.Comment;
 import com.example.picket.domain.comment.repository.CommentRepository;
 import com.example.picket.domain.seat.entity.Seat;
@@ -47,7 +50,7 @@ class CommentQueryServiceTest {
     private CommentQueryService commentQueryService;
 
     @Test
-    void 댓글_다건_조회_성공(){
+    void 댓글_다건_조회_성공() {
         // given
         Long userId1 = 1L;
         User user1 = createUser(userId1);
@@ -58,10 +61,10 @@ class CommentQueryServiceTest {
         Long showId = 1L;
         Show show = createShow(user1, showId);
 
-        Comment comment1 = Comment.toEntity("댓글내용1", show, user1);
+        Comment comment1 = Comment.create("댓글내용1", show, user1);
         ReflectionTestUtils.setField(comment1, "id", 1L);
 
-        Comment comment2 = Comment.toEntity("댓글내용2", show, user1);
+        Comment comment2 = Comment.create("댓글내용2", show, user1);
         ReflectionTestUtils.setField(comment2, "id", 2L);
         List<Comment> commentList = Arrays.asList(comment1, comment2);
 
@@ -81,11 +84,11 @@ class CommentQueryServiceTest {
     }
 
     private User createUser(Long userId) {
-        User user = User.toEntity("user@example.com"
-                ,"test123!"
+        User user = User.create("user@example.com"
+                , "test123!"
                 , UserRole.USER
-                ,null
-                ,"닉네임"
+                , null
+                , "닉네임"
                 , LocalDate.parse("1990-06-25")
                 , Gender.FEMALE);
 
@@ -95,8 +98,8 @@ class CommentQueryServiceTest {
     }
 
     private Show createShow(User user, Long showId) {
-        Show show = Show.toEntity(user.getId()
-                ,"제목"
+        Show show = Show.create(user.getId()
+                , "제목"
                 , "포스터url"
                 , Category.CLASSIC
                 , "description"
@@ -113,7 +116,7 @@ class CommentQueryServiceTest {
     }
 
     private ShowDate createShowDate(Show show, Long showDateId) {
-        ShowDate showDate = ShowDate.toEntity(LocalDate.now()
+        ShowDate showDate = ShowDate.create(LocalDate.now()
                 , LocalTime.now()
                 , LocalTime.now().plusHours(1)
                 , 10
@@ -126,7 +129,7 @@ class CommentQueryServiceTest {
     }
 
     private Seat createSeat(ShowDate showDate, Long seatId) {
-        Seat seat = Seat.toEntity(Grade.A
+        Seat seat = Seat.create(Grade.A
                 , 1
                 , new BigDecimal(100000)
                 , showDate);

--- a/src/test/java/com/example/picket/domain/like/service/LikeQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/like/service/LikeQueryServiceTest.java
@@ -1,11 +1,5 @@
 package com.example.picket.domain.like.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.example.picket.common.enums.Category;
 import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.UserRole;
@@ -14,10 +8,6 @@ import com.example.picket.domain.like.repository.LikeRepository;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.show.service.ShowQueryService;
 import com.example.picket.domain.user.entity.User;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +16,17 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class LikeQueryServiceTest {
@@ -68,15 +69,15 @@ class LikeQueryServiceTest {
             int page = 0;
             int size = 10;
 
-            User user = User.toEntity("test@example.com", "!Password1234", UserRole.USER, null, "nickname1",
+            User user = User.create("test@example.com", "!Password1234", UserRole.USER, null, "nickname1",
                     LocalDate.of(2000, 12, 12), Gender.MALE);
-            Show show1 = Show.toEntity(1L, "Show 1", "image1.png", Category.CONCERT, "desc1",
+            Show show1 = Show.create(1L, "Show 1", "image1.png", Category.CONCERT, "desc1",
                     "location1", LocalDateTime.now(), LocalDateTime.now().plusDays(3), 3);
-            Show show2 = Show.toEntity(2L, "Show 2", "image2.png", Category.MUSICAL, "desc2",
+            Show show2 = Show.create(2L, "Show 2", "image2.png", Category.MUSICAL, "desc2",
                     "location2", LocalDateTime.now(), LocalDateTime.now().plusDays(5), 5);
 
-            Like like1 = Like.toEntity(show1, user);
-            Like like2 = Like.toEntity(show2, user);
+            Like like1 = Like.create(show1, user);
+            Like like2 = Like.create(show2, user);
 
             List<Like> likeList = List.of(like1, like2);
             List<Show> showList = List.of(show1, show2);
@@ -101,13 +102,13 @@ class LikeQueryServiceTest {
             int page = 1;
             int size = 1; // 한 페이지에 1개만 조회
 
-            User user = User.toEntity("test@example.com", "!Password1234", UserRole.USER, null, "nickname1",
+            User user = User.create("test@example.com", "!Password1234", UserRole.USER, null, "nickname1",
                     LocalDate.of(2000, 12, 12), Gender.MALE);
 
-            Show show1 = Show.toEntity(1L, "Show 1", "image1.png", Category.CONCERT, "desc1",
+            Show show1 = Show.create(1L, "Show 1", "image1.png", Category.CONCERT, "desc1",
                     "location1", LocalDateTime.now(), LocalDateTime.now().plusDays(3), 3);
 
-            Like like1 = Like.toEntity(show1, user);
+            Like like1 = Like.create(show1, user);
 
             List<Like> likeList = List.of(like1); // 한 개만 반환
             List<Show> showList = List.of(show1);

--- a/src/test/java/com/example/picket/domain/order/service/OrderCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/order/service/OrderCommandServiceTest.java
@@ -41,7 +41,7 @@ class OrderCommandServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = User.toEntity(
+        user = User.create(
                 "user@example.com", "encodedPw", UserRole.USER, null, "nickname",
                 LocalDate.of(1990, 1, 1), Gender.MALE
         );

--- a/src/test/java/com/example/picket/domain/order/service/OrderQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/order/service/OrderQueryServiceTest.java
@@ -47,7 +47,7 @@ class OrderQueryServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = User.toEntity(
+        user = User.create(
                 "user@example.com", "encodedPw", UserRole.USER, null, "nickname",
                 LocalDate.of(1990, 1, 1), Gender.MALE
         );

--- a/src/test/java/com/example/picket/domain/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ranking/service/RankingServiceTest.java
@@ -74,8 +74,8 @@ class RankingServiceTest {
                 "{\"category\":\"CONCERT\",\"keywordCount\":50,\"createdAt\":\"2025-04-21T10:00:00\"}"
         );
 
-        PopularKeyword keyword1 = PopularKeyword.toEntity(Category.MUSICAL, 100L, now);
-        PopularKeyword keyword2 = PopularKeyword.toEntity(Category.CONCERT, 50L, now);
+        PopularKeyword keyword1 = PopularKeyword.create(Category.MUSICAL, 100L, now);
+        PopularKeyword keyword2 = PopularKeyword.create(Category.CONCERT, 50L, now);
 
         when(listOperations.range("ranking:popular_keywords", 0, -1)).thenReturn(jsonKeywords);
         when(objectMapper.readValue(jsonKeywords.get(0), PopularKeyword.class)).thenReturn(keyword1);
@@ -128,11 +128,12 @@ class RankingServiceTest {
                 "{\"category\":\"CONCERT\",\"keywordCount\":50,\"createdAt\":\"2025-04-21T10:00:00\"}"
         );
 
-        PopularKeyword keyword1 = PopularKeyword.toEntity(Category.MUSICAL, 100L, now);
+        PopularKeyword keyword1 = PopularKeyword.create(Category.MUSICAL, 100L, now);
 
         when(listOperations.range("ranking:popular_keywords", 0, -1)).thenReturn(jsonKeywords);
         when(objectMapper.readValue(jsonKeywords.get(0), PopularKeyword.class)).thenReturn(keyword1);
-        when(objectMapper.readValue(jsonKeywords.get(1), PopularKeyword.class)).thenThrow(new JsonProcessingException("Error") {});
+        when(objectMapper.readValue(jsonKeywords.get(1), PopularKeyword.class)).thenThrow(new JsonProcessingException("Error") {
+        });
 
         // When
         List<PopularKeywordResponse> result = rankingService.getPopularKeywords();
@@ -167,8 +168,8 @@ class RankingServiceTest {
                 "{\"showId\":2,\"title\":\"Show2\",\"viewCount\":500,\"status\":\"PERFORMANCE_ONGOING\",\"createdAt\":\"2025-04-21T10:00:00\"}"
         );
 
-        HotShow show1 = HotShow.toEntity(1L, "Show1", 1000, ShowStatus.RESERVATION_ONGOING, now);
-        HotShow show2 = HotShow.toEntity(2L, "Show2", 500, ShowStatus.PERFORMANCE_ONGOING, now);
+        HotShow show1 = HotShow.create(1L, "Show1", 1000, ShowStatus.RESERVATION_ONGOING, now);
+        HotShow show2 = HotShow.create(2L, "Show2", 500, ShowStatus.PERFORMANCE_ONGOING, now);
 
         when(listOperations.range("ranking:hot_shows", 0, -1)).thenReturn(jsonShows);
         when(objectMapper.readValue(jsonShows.get(0), HotShow.class)).thenReturn(show1);
@@ -240,11 +241,12 @@ class RankingServiceTest {
                 "{\"showId\":2,\"title\":\"Show2\",\"viewCount\":500,\"status\":\"PERFORMANCE_ONGOING\",\"createdAt\":\"2025-04-21T10:00:00\"}"
         );
 
-        HotShow show1 = HotShow.toEntity(1L, "Show1", 1000, ShowStatus.RESERVATION_ONGOING, now);
+        HotShow show1 = HotShow.create(1L, "Show1", 1000, ShowStatus.RESERVATION_ONGOING, now);
 
         when(listOperations.range("ranking:hot_shows", 0, -1)).thenReturn(jsonShows);
         when(objectMapper.readValue(jsonShows.get(0), HotShow.class)).thenReturn(show1);
-        when(objectMapper.readValue(jsonShows.get(1), HotShow.class)).thenThrow(new JsonProcessingException("Error") {});
+        when(objectMapper.readValue(jsonShows.get(1), HotShow.class)).thenThrow(new JsonProcessingException("Error") {
+        });
 
         // When
         List<HotShowResponse> result = rankingService.getHotShows();
@@ -281,8 +283,8 @@ class RankingServiceTest {
                 "{\"showId\":2,\"title\":\"Show2\",\"likeCount\":300,\"status\":\"PERFORMANCE_ONGOING\",\"createdAt\":\"2025-04-21T10:00:00\"}"
         );
 
-        LikeShow show1 = LikeShow.toEntity(1L, "Show1", 500L, ShowStatus.RESERVATION_ONGOING, now);
-        LikeShow show2 = LikeShow.toEntity(2L , "Show2", 300L, ShowStatus.PERFORMANCE_ONGOING, now);
+        LikeShow show1 = LikeShow.create(1L, "Show1", 500L, ShowStatus.RESERVATION_ONGOING, now);
+        LikeShow show2 = LikeShow.create(2L, "Show2", 300L, ShowStatus.PERFORMANCE_ONGOING, now);
 
         when(listOperations.range("ranking:like_shows", 0, -1)).thenReturn(jsonShows);
         when(objectMapper.readValue(jsonShows.get(0), LikeShow.class)).thenReturn(show1);
@@ -353,11 +355,12 @@ class RankingServiceTest {
                 "{\"showId\":2,\"title\":\"Show2\",\"likeCount\":300,\"status\":\"PERFORMANCE_ONGOING\",\"createdAt\":\"2025-04-21T10:00:00\"}"
         );
 
-        LikeShow show1 = LikeShow.toEntity(1L, "Show1", 500L, ShowStatus.RESERVATION_ONGOING, now);
+        LikeShow show1 = LikeShow.create(1L, "Show1", 500L, ShowStatus.RESERVATION_ONGOING, now);
 
         when(listOperations.range("ranking:like_shows", 0, -1)).thenReturn(jsonShows);
         when(objectMapper.readValue(jsonShows.get(0), LikeShow.class)).thenReturn(show1);
-        when(objectMapper.readValue(jsonShows.get(1), LikeShow.class)).thenThrow(new JsonProcessingException("Error") {});
+        when(objectMapper.readValue(jsonShows.get(1), LikeShow.class)).thenThrow(new JsonProcessingException("Error") {
+        });
 
         // When
         List<LikeShowResponse> result = rankingService.getLikeShows();

--- a/src/test/java/com/example/picket/domain/seat/service/SeatCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/seat/service/SeatCommandServiceTest.java
@@ -1,7 +1,10 @@
 package com.example.picket.domain.seat.service;
 
 import com.example.picket.common.dto.AuthUser;
-import com.example.picket.common.enums.*;
+import com.example.picket.common.enums.Category;
+import com.example.picket.common.enums.Grade;
+import com.example.picket.common.enums.SeatStatus;
+import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.seat.dto.request.SeatUpdateRequest;
 import com.example.picket.domain.seat.entity.Seat;
@@ -41,7 +44,7 @@ class SeatCommandServiceTest {
     @InjectMocks
     private SeatCommandService seatCommandService;
 
-    private final AuthUser adminUser = AuthUser.toEntity(1L, UserRole.ADMIN);
+    private final AuthUser adminUser = AuthUser.create(1L, UserRole.ADMIN);
 
     @Nested
     class 좌석_수정_테스트 {
@@ -50,10 +53,10 @@ class SeatCommandServiceTest {
         void 좌석이_추가되는_경우_새로운_좌석_저장() {
             // given
             Long showDateId = 1L;
-            Show show = Show.toEntity(1L, "테스트 공연", "image.png", Category.CONCERT, "설명",
+            Show show = Show.create(1L, "테스트 공연", "image.png", Category.CONCERT, "설명",
                     "장소", LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1), 1);
             LocalDateTime dateTime = LocalDateTime.now().plusDays(1);
-            ShowDate showDate = ShowDate.toEntity(
+            ShowDate showDate = ShowDate.create(
                     dateTime.toLocalDate(),
                     dateTime.toLocalTime(),
                     dateTime.toLocalTime().plusHours(2),
@@ -64,13 +67,13 @@ class SeatCommandServiceTest {
             Grade grade = Grade.VIP;
             BigDecimal newPrice = BigDecimal.valueOf(10000);
 
-            Seat existingSeat = Seat.toEntity(grade, 1, newPrice, showDate);
+            Seat existingSeat = Seat.create(grade, 1, newPrice, showDate);
 
             given(showDateQueryService.getShowDate(showDateId)).willReturn(showDate);
             given(seatRepository.findAllByShowDateId(showDateId)).willReturn(List.of(existingSeat));
             given(seatRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
 
-            SeatUpdateRequest request = SeatUpdateRequest.toDto(grade.name(), 3, newPrice);
+            SeatUpdateRequest request = SeatUpdateRequest.of(grade.name(), 3, newPrice);
 
             // when
             List<Seat> updatedSeats = seatCommandService.updateSeats(adminUser, showDateId, List.of(request));
@@ -84,10 +87,10 @@ class SeatCommandServiceTest {
         void 좌석이_감소되는_경우_예약되지_않은_좌석만_삭제() {
             // given
             Long showDateId = 1L;
-            Show show = Show.toEntity(1L, "공연", "image.png", Category.CONCERT, "desc",
+            Show show = Show.create(1L, "공연", "image.png", Category.CONCERT, "desc",
                     "장소", LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2), 1);
 
-            ShowDate showDate = ShowDate.toEntity(
+            ShowDate showDate = ShowDate.create(
                     LocalDate.now().plusDays(2),
                     LocalTime.of(19, 0),
                     LocalTime.of(21, 0),
@@ -95,13 +98,13 @@ class SeatCommandServiceTest {
 
             BigDecimal price = BigDecimal.valueOf(10000);
 
-            Seat seat1 = Seat.toEntity(Grade.VIP, 1, price, showDate);
-            Seat seat2 = Seat.toEntity(Grade.VIP, 2, price, showDate);
+            Seat seat1 = Seat.create(Grade.VIP, 1, price, showDate);
+            Seat seat2 = Seat.create(Grade.VIP, 2, price, showDate);
 
             given(showDateQueryService.getShowDate(showDateId)).willReturn(showDate);
             given(seatRepository.findAllByShowDateId(showDateId)).willReturn(List.of(seat1, seat2));
 
-            SeatUpdateRequest request = SeatUpdateRequest.toDto(Grade.VIP.name(), 1, price);
+            SeatUpdateRequest request = SeatUpdateRequest.of(Grade.VIP.name(), 1, price);
 
             // when
             List<Seat> updated = seatCommandService.updateSeats(adminUser, showDateId, List.of(request));
@@ -114,10 +117,10 @@ class SeatCommandServiceTest {
         void 예약시작_후_좌석_감소_불가() {
             // given
             Long showDateId = 1L;
-            Show show = Show.toEntity(1L, "공연", "image.png", Category.CONCERT, "desc",
+            Show show = Show.create(1L, "공연", "image.png", Category.CONCERT, "desc",
                     "장소", LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(2), 1);
 
-            ShowDate showDate = ShowDate.toEntity(
+            ShowDate showDate = ShowDate.create(
                     LocalDate.now().plusDays(1),
                     LocalTime.of(19, 0),
                     LocalTime.of(21, 0),
@@ -125,13 +128,13 @@ class SeatCommandServiceTest {
 
             BigDecimal price = BigDecimal.valueOf(10000);
 
-            Seat seat1 = Seat.toEntity(Grade.VIP, 1, price, showDate);
-            Seat seat2 = Seat.toEntity(Grade.VIP, 2, price, showDate);
+            Seat seat1 = Seat.create(Grade.VIP, 1, price, showDate);
+            Seat seat2 = Seat.create(Grade.VIP, 2, price, showDate);
 
             given(showDateQueryService.getShowDate(showDateId)).willReturn(showDate);
             given(seatRepository.findAllByShowDateId(showDateId)).willReturn(List.of(seat1, seat2));
 
-            SeatUpdateRequest request = SeatUpdateRequest.toDto(Grade.VIP.name(), 1, price);
+            SeatUpdateRequest request = SeatUpdateRequest.of(Grade.VIP.name(), 1, price);
 
             // when & then
             assertThatThrownBy(() -> seatCommandService.updateSeats(adminUser, showDateId, List.of(request)))
@@ -144,7 +147,7 @@ class SeatCommandServiceTest {
         @Test
         void 예매_시작_이후에는_좌석_수_감소_불가() {
             // given
-            Show show = Show.toEntity(
+            Show show = Show.create(
                     1L, "공연", "image.png", Category.CONCERT, "desc",
                     "장소",
                     LocalDateTime.now().minusDays(1),
@@ -152,7 +155,7 @@ class SeatCommandServiceTest {
                     1
             );
 
-            ShowDate showDate = ShowDate.toEntity(
+            ShowDate showDate = ShowDate.create(
                     LocalDate.now().plusDays(1),
                     LocalTime.of(19, 0),
                     LocalTime.of(21, 0),
@@ -163,13 +166,13 @@ class SeatCommandServiceTest {
             given(showDateQueryService.getShowDate(showDate.getId()))
                     .willReturn(showDate);
 
-            Seat reservedSeat = Seat.toEntity(Grade.VIP, 1, price, showDate);
+            Seat reservedSeat = Seat.create(Grade.VIP, 1, price, showDate);
             ReflectionTestUtils.setField(reservedSeat, "seatStatus", SeatStatus.RESERVED);
 
             given(seatRepository.findAllByShowDateId(showDate.getId()))
                     .willReturn(List.of(reservedSeat));
 
-            SeatUpdateRequest request = SeatUpdateRequest.toDto(Grade.VIP.name(), 0, price);
+            SeatUpdateRequest request = SeatUpdateRequest.of(Grade.VIP.name(), 0, price);
 
             // when & then
             assertThatThrownBy(() -> seatCommandService.updateSeats(adminUser, showDate.getId(), List.of(request)))
@@ -180,7 +183,7 @@ class SeatCommandServiceTest {
         @Test
         void 좌석_줄이기_요청시_예약된_좌석_때문에_실패() {
             // given
-            Show show = Show.toEntity(
+            Show show = Show.create(
                     1L, "공연", "image.png", Category.CONCERT, "desc",
                     "장소",
                     LocalDateTime.now().plusDays(1),  // 예매 시작 전
@@ -188,7 +191,7 @@ class SeatCommandServiceTest {
                     1
             );
 
-            ShowDate showDate = ShowDate.toEntity(
+            ShowDate showDate = ShowDate.create(
                     LocalDate.now().plusDays(1),
                     LocalTime.of(19, 0),
                     LocalTime.of(21, 0),
@@ -201,8 +204,8 @@ class SeatCommandServiceTest {
                     .willReturn(showDate);
 
             // 현재 좌석 2개 중 1개는 예약된 상태 (줄일 수 없음)
-            Seat reservedSeat = Seat.toEntity(Grade.VIP, 1, price, showDate);
-            Seat availableSeat = Seat.toEntity(Grade.VIP, 2, price, showDate);
+            Seat reservedSeat = Seat.create(Grade.VIP, 1, price, showDate);
+            Seat availableSeat = Seat.create(Grade.VIP, 2, price, showDate);
 
             ReflectionTestUtils.setField(reservedSeat, "seatStatus", SeatStatus.RESERVED);
             ReflectionTestUtils.setField(availableSeat, "seatStatus", SeatStatus.AVAILABLE);
@@ -211,7 +214,7 @@ class SeatCommandServiceTest {
                     .willReturn(List.of(reservedSeat, availableSeat));
 
             // 요청: 좌석 수 2개 → 0개로 줄이기 (2개 줄여야 하는데 예약된 좌석 때문에 불가)
-            SeatUpdateRequest request = SeatUpdateRequest.toDto(Grade.VIP.name(), 0, price);
+            SeatUpdateRequest request = SeatUpdateRequest.of(Grade.VIP.name(), 0, price);
 
             // when & then
             assertThatThrownBy(() -> seatCommandService.updateSeats(adminUser, showDate.getId(), List.of(request)))
@@ -233,7 +236,7 @@ class SeatCommandServiceTest {
             given(show.getReservationStart()).willReturn(LocalDateTime.now().plusDays(1));
             given(show.getDirectorId()).willReturn(adminUser.getId());
 
-            Seat seat = Seat.toEntity(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
+            Seat seat = Seat.create(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
             given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
             // when
@@ -253,7 +256,7 @@ class SeatCommandServiceTest {
             given(show.getReservationStart()).willReturn(LocalDateTime.now().plusDays(1));
             given(show.getDirectorId()).willReturn(adminUser.getId());
 
-            Seat seat = Seat.toEntity(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
+            Seat seat = Seat.create(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
             ReflectionTestUtils.setField(seat, "seatStatus", SeatStatus.RESERVED);// 좌석 상태를 RESERVED로 설정
 
             given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
@@ -277,7 +280,7 @@ class SeatCommandServiceTest {
             given(show.getId()).willReturn(showId);
             given(show.getDirectorId()).willReturn(adminUser.getId());
 
-            Seat seat = Seat.toEntity(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
+            Seat seat = Seat.create(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
             given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
             given(showDateQueryService.getShowDatesByShowId(showId)).willReturn(List.of(showDate));
 
@@ -301,7 +304,7 @@ class SeatCommandServiceTest {
             given(show.getDirectorId()).willReturn(adminUser.getId());
             given(show.getReservationStart()).willReturn(LocalDateTime.now().minusDays(1));
 
-            Seat seat = Seat.toEntity(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
+            Seat seat = Seat.create(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
             given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
             given(showDateQueryService.getShowDatesByShowId(showId)).willReturn(List.of(showDate));
 
@@ -320,7 +323,7 @@ class SeatCommandServiceTest {
             Show show = mock(Show.class);
             given(showDate.getShow()).willReturn(show);
 
-            Seat seat = Seat.toEntity(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
+            Seat seat = Seat.create(Grade.VIP, 1, BigDecimal.valueOf(10000), showDate);
             given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
             // when & then

--- a/src/test/java/com/example/picket/domain/show/service/ShowCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/show/service/ShowCommandServiceTest.java
@@ -327,7 +327,7 @@ class ShowCommandServiceTest {
             setShowId(show, showId);
             ReflectionTestUtils.setField(show, "reservationStart", now.plusDays(1));
             ReflectionTestUtils.setField(show, "directorId", authUser.getId());
-
+            ShowImage showImage = mock(ShowImage.class);
             ShowDate showDate = createShowDate(
                     dateNow,
                     LocalTime.of(10, 0),
@@ -342,7 +342,8 @@ class ShowCommandServiceTest {
             given(showDateQueryService.getShowDatesByShowId(showId)).willReturn(List.of(showDate));
             given(seatQueryService.getSeatsByShowDate(showDateId)).willReturn(seats);
             doNothing().when(seatCommandService).deleteAll(seats);
-
+            given(showImageRepository.findByImageUrl(any())).willReturn(Optional.of(showImage));
+            doNothing().when(showImageRepository).delete(any());
             // when
             showCommandService.deleteShow(authUser, showId);
 

--- a/src/test/java/com/example/picket/domain/show/service/ShowCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/show/service/ShowCommandServiceTest.java
@@ -1,17 +1,5 @@
 package com.example.picket.domain.show.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.enums.Category;
 import com.example.picket.common.enums.Grade;
@@ -31,14 +19,6 @@ import com.example.picket.domain.show.dto.request.ShowUpdateRequest;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.show.entity.ShowDate;
 import com.example.picket.domain.show.repository.ShowRepository;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,6 +27,22 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ShowCommandServiceTest {
@@ -79,7 +75,7 @@ class ShowCommandServiceTest {
 
     @BeforeEach
     void setUp() {
-        authUser = AuthUser.toEntity(1L, UserRole.DIRECTOR);
+        authUser = AuthUser.create(1L, UserRole.DIRECTOR);
     }
 
     @Nested
@@ -294,7 +290,7 @@ class ShowCommandServiceTest {
             Show show = createShow(now);
             setShowId(show, showId);
 
-            ShowDate showDate = ShowDate.toEntity(LocalDate.now().minusDays(1),
+            ShowDate showDate = ShowDate.create(LocalDate.now().minusDays(1),
                     LocalTime.of(10, 0), LocalTime.of(12, 0), 100, 0, show);
 
             given(showRepository.findById(showId)).willReturn(Optional.of(show));
@@ -434,7 +430,7 @@ class ShowCommandServiceTest {
     }
 
     private Show createShow(LocalDateTime now) {
-        return Show.toEntity(
+        return Show.create(
                 authUser.getId(),
                 "원래 제목",
                 "origin.jpg",
@@ -448,7 +444,7 @@ class ShowCommandServiceTest {
     }
 
     private Show createShow(LocalDateTime reservationStart, LocalDateTime reservationEnd) {
-        return Show.toEntity(
+        return Show.create(
                 authUser.getId(),
                 "원래 제목",
                 "origin.jpg",
@@ -462,7 +458,7 @@ class ShowCommandServiceTest {
     }
 
     private Show createShow(ShowCreateRequest request) {
-        return Show.toEntity(
+        return Show.create(
                 authUser.getId(),
                 request.getTitle(),
                 request.getPosterUrl(),
@@ -481,7 +477,7 @@ class ShowCommandServiceTest {
             LocalTime endTime,
             Show show
     ) {
-        return ShowDate.toEntity(
+        return ShowDate.create(
                 now,
                 startTime,
                 endTime,
@@ -494,7 +490,7 @@ class ShowCommandServiceTest {
     private List<ShowDate> createShowDates(Show show, List<ShowDateRequest> dateRequests) {
         List<ShowDate> showDates = new ArrayList<>();
         for (int i = 0; i < dateRequests.size(); i++) {
-            ShowDate showDate = ShowDate.toEntity(
+            ShowDate showDate = ShowDate.create(
                     dateRequests.get(i).getDate(),
                     dateRequests.get(i).getStartTime(),
                     dateRequests.get(i).getEndTime(),

--- a/src/test/java/com/example/picket/domain/show/service/ShowDateCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/show/service/ShowDateCommandServiceTest.java
@@ -66,7 +66,7 @@ class ShowDateCommandServiceTest {
 
         @Test
         void 좌석수_업데이트_성공_테스트() {
-           // given
+            // given
             Long showId = 1L;
             Long showDateId = 1L;
 
@@ -82,17 +82,17 @@ class ShowDateCommandServiceTest {
             setShowDateId(showDate, showDateId);
             given(showDateRepository.findById(showDateId)).willReturn(Optional.of(showDate));
 
-           // when
-           showDateCommandService.countUpdate(showDateId, 1);
+            // when
+            showDateCommandService.countUpdate(showDateId, 1);
 
-           // then
+            // then
             assertEquals(showDate.getAvailableSeatCount(), 99);
             assertEquals(showDate.getReservedSeatCount(), 1);
         }
     }
 
     private Show createShow(LocalDateTime now) {
-        return Show.toEntity(
+        return Show.create(
                 1L,
                 "원래 제목",
                 "origin.jpg",
@@ -111,7 +111,7 @@ class ShowDateCommandServiceTest {
             LocalTime endTime,
             Show show
     ) {
-        return ShowDate.toEntity(
+        return ShowDate.create(
                 now,
                 startTime,
                 endTime,

--- a/src/test/java/com/example/picket/domain/show/service/ShowDateQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/show/service/ShowDateQueryServiceTest.java
@@ -199,7 +199,7 @@ class ShowDateQueryServiceTest {
     }
 
     private Show createShow(LocalDateTime now) {
-        return Show.toEntity(
+        return Show.create(
                 1L,
                 "원래 제목",
                 "origin.jpg",
@@ -218,7 +218,7 @@ class ShowDateQueryServiceTest {
             LocalTime endTime,
             Show show
     ) {
-        return ShowDate.toEntity(
+        return ShowDate.create(
                 now,
                 startTime,
                 endTime,

--- a/src/test/java/com/example/picket/domain/show/service/ShowQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/show/service/ShowQueryServiceTest.java
@@ -56,9 +56,9 @@ class ShowQueryServiceTest {
             LocalDateTime reservationStart = now;
             LocalDateTime reservationEnd = now.plusDays(1);
 
-            Show show = Show.toEntity(1L, "제목1", "포스터1.jpg",
-                Category.MUSICAL, "내용1", "장소1",
-                reservationStart, reservationEnd, 2
+            Show show = Show.create(1L, "제목1", "포스터1.jpg",
+                    Category.MUSICAL, "내용1", "장소1",
+                    reservationStart, reservationEnd, 2
             );
 
             setCreatedAt(show, now);
@@ -72,14 +72,14 @@ class ShowQueryServiceTest {
             // then
             assertThat(result).hasSize(1);
             assertThat(result)
-                .extracting("directorId", "title", "posterUrl", "category",
-                    "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
-                )
-                .containsExactly(
-                    tuple(1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
-                        reservationStart, reservationEnd, 2
+                    .extracting("directorId", "title", "posterUrl", "category",
+                            "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
                     )
-                );
+                    .containsExactly(
+                            tuple(1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
+                                    reservationStart, reservationEnd, 2
+                            )
+                    );
             verify(showRepository, times(1)).findAllByCategoryAndDeletedAtIsNull(Category.MUSICAL);
         }
 
@@ -90,9 +90,9 @@ class ShowQueryServiceTest {
             LocalDateTime reservationStart = now;
             LocalDateTime reservationEnd = now.plusDays(1);
 
-            Show show = Show.toEntity(1L, "제목1", "포스터1.jpg",
-                Category.MUSICAL, "내용1", "장소1",
-                reservationStart, reservationEnd, 2
+            Show show = Show.create(1L, "제목1", "포스터1.jpg",
+                    Category.MUSICAL, "내용1", "장소1",
+                    reservationStart, reservationEnd, 2
             );
             setCreatedAt(show, now);
 
@@ -105,14 +105,14 @@ class ShowQueryServiceTest {
             // then
             assertThat(result).hasSize(1);
             assertThat(result)
-                .extracting("directorId", "title", "posterUrl", "category",
-                    "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
-                )
-                .containsExactly(
-                    tuple(1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
-                        reservationStart, reservationEnd, 2
+                    .extracting("directorId", "title", "posterUrl", "category",
+                            "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
                     )
-                );
+                    .containsExactly(
+                            tuple(1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
+                                    reservationStart, reservationEnd, 2
+                            )
+                    );
             verify(showRepository, times(1)).findAllByCategoryAndDeletedAtIsNull(Category.MUSICAL);
         }
 
@@ -120,8 +120,8 @@ class ShowQueryServiceTest {
         void 공연_목록_조회_유효하지_않은_order_예외() throws Exception {
             // when & then
             assertThatThrownBy(() -> showQueryService.getShows(Category.MUSICAL, "createdAt", "invalidOrder"))
-                .isInstanceOf(CustomException.class)
-                .hasMessage("유효하지 않은 정렬 방식입니다. (asc, desc만 허용)");
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("유효하지 않은 정렬 방식입니다. (asc, desc만 허용)");
         }
 
     }
@@ -136,21 +136,21 @@ class ShowQueryServiceTest {
             LocalDateTime reservationStart = now;
             LocalDateTime reservationEnd = now.plusDays(1);
 
-            Show show = Show.toEntity(1L, "제목1", "포스터1.jpg",
-                Category.MUSICAL, "내용1", "장소1",
-                reservationStart, reservationEnd, 2
+            Show show = Show.create(1L, "제목1", "포스터1.jpg",
+                    Category.MUSICAL, "내용1", "장소1",
+                    reservationStart, reservationEnd, 2
             );
             setCreatedAt(show, now);
             setModifiedAt(show, now);
 
             List<ShowDateResponse> showDateResponses = new ArrayList<>();
-            ShowResponse showResponse = ShowResponse.toDto(show, showDateResponses);
+            ShowResponse showResponse = ShowResponse.of(show, showDateResponses);
 
             List<ShowResponse> mockShows = new ArrayList<>(List.of(showResponse));
             Page<ShowResponse> mockPage = new PageImpl<>(mockShows, PageRequest.of(0, 10), 1);
 
             given(showRepository.getShowsResponse(Category.MUSICAL, "createdAt", "desc", PageRequest.of(0, 10)))
-                .willReturn(mockPage);
+                    .willReturn(mockPage);
 
             // when
             Page<ShowResponse> result = showQueryService.getShows(Category.MUSICAL, "createdAt", "desc", 1, 10);
@@ -159,16 +159,16 @@ class ShowQueryServiceTest {
             assertThat(result.getContent()).hasSize(1);
             assertThat(result.getTotalElements()).isEqualTo(1);
             assertThat(result.getContent())
-                .extracting("directorId", "title", "posterUrl", "category",
-                    "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
-                )
-                .containsExactly(
-                    tuple(1L, "제목1", "포스터1.jpg", Category.MUSICAL.name(), "내용1", "장소1",
-                        reservationStart.toString(), reservationEnd.toString(), 2
+                    .extracting("directorId", "title", "posterUrl", "category",
+                            "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
                     )
-                );
+                    .containsExactly(
+                            tuple(1L, "제목1", "포스터1.jpg", Category.MUSICAL.name(), "내용1", "장소1",
+                                    reservationStart.toString(), reservationEnd.toString(), 2
+                            )
+                    );
             verify(showRepository, times(1))
-                .getShowsResponse(Category.MUSICAL, "createdAt", "desc", PageRequest.of(0, 10));
+                    .getShowsResponse(Category.MUSICAL, "createdAt", "desc", PageRequest.of(0, 10));
         }
 
         @Test
@@ -178,21 +178,21 @@ class ShowQueryServiceTest {
             LocalDateTime reservationStart = now;
             LocalDateTime reservationEnd = now.plusDays(1);
 
-            Show show = Show.toEntity(1L, "제목1", "포스터1.jpg",
-                Category.MUSICAL, "내용1", "장소1",
-                reservationStart, reservationEnd, 2
+            Show show = Show.create(1L, "제목1", "포스터1.jpg",
+                    Category.MUSICAL, "내용1", "장소1",
+                    reservationStart, reservationEnd, 2
             );
             setCreatedAt(show, now);
             setModifiedAt(show, now);
 
             List<ShowDateResponse> showDateResponses = new ArrayList<>();
-            ShowResponse showResponse = ShowResponse.toDto(show, showDateResponses);
+            ShowResponse showResponse = ShowResponse.of(show, showDateResponses);
 
             List<ShowResponse> mockShows = new ArrayList<>(List.of(showResponse));
             Page<ShowResponse> mockPage = new PageImpl<>(mockShows, PageRequest.of(0, 10), 1);
 
             given(showRepository.getShowsResponse(Category.MUSICAL, "reservationStart", "desc", PageRequest.of(0, 10)))
-                .willReturn(mockPage);
+                    .willReturn(mockPage);
 
             // when
             Page<ShowResponse> result = showQueryService.getShows(Category.MUSICAL, "reservationStart", "desc", 1, 10);
@@ -201,28 +201,28 @@ class ShowQueryServiceTest {
             assertThat(result.getContent()).hasSize(1);
             assertThat(result.getTotalElements()).isEqualTo(1);
             assertThat(result.getContent())
-                .extracting("directorId", "title", "posterUrl", "category",
-                    "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
-                )
-                .containsExactly(
-                    tuple(1L, "제목1", "포스터1.jpg", Category.MUSICAL.name(), "내용1", "장소1",
-                        reservationStart.toString(), reservationEnd.toString(), 2
+                    .extracting("directorId", "title", "posterUrl", "category",
+                            "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
                     )
-                );
+                    .containsExactly(
+                            tuple(1L, "제목1", "포스터1.jpg", Category.MUSICAL.name(), "내용1", "장소1",
+                                    reservationStart.toString(), reservationEnd.toString(), 2
+                            )
+                    );
             verify(showRepository, times(1))
-                .getShowsResponse(Category.MUSICAL, "reservationStart", "desc", PageRequest.of(0, 10));
+                    .getShowsResponse(Category.MUSICAL, "reservationStart", "desc", PageRequest.of(0, 10));
         }
 
         @Test
         void 공연_목록_조회_유효하지_않은_order_예외() throws Exception {
             // given
             given(showRepository.getShowsResponse(Category.MUSICAL, "createdAt", "invalidOrder", PageRequest.of(0, 10)))
-                .willThrow(new CustomException(HttpStatus.BAD_REQUEST, "유효하지 않은 정렬 방식입니다. (asc, desc만 허용)"));
+                    .willThrow(new CustomException(HttpStatus.BAD_REQUEST, "유효하지 않은 정렬 방식입니다. (asc, desc만 허용)"));
 
             // when & then
             assertThatThrownBy(() -> showQueryService.getShows(Category.MUSICAL, "createdAt", "invalidOrder", 1, 10))
-                .isInstanceOf(CustomException.class)
-                .hasMessage("유효하지 않은 정렬 방식입니다. (asc, desc만 허용)");
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("유효하지 않은 정렬 방식입니다. (asc, desc만 허용)");
         }
 
         @Test
@@ -232,21 +232,21 @@ class ShowQueryServiceTest {
             LocalDateTime reservationStart = now;
             LocalDateTime reservationEnd = now.plusDays(1);
 
-            Show show = Show.toEntity(1L, "제목1", "포스터1.jpg",
-                Category.MUSICAL, "내용1", "장소1",
-                reservationStart, reservationEnd, 2
+            Show show = Show.create(1L, "제목1", "포스터1.jpg",
+                    Category.MUSICAL, "내용1", "장소1",
+                    reservationStart, reservationEnd, 2
             );
             setCreatedAt(show, now);
             setModifiedAt(show, now);
 
             List<ShowDateResponse> showDateResponses = new ArrayList<>();
-            ShowResponse showResponse = ShowResponse.toDto(show, showDateResponses);
+            ShowResponse showResponse = ShowResponse.of(show, showDateResponses);
 
             List<ShowResponse> mockShows = new ArrayList<>(List.of(showResponse));
             Page<ShowResponse> mockPage = new PageImpl<>(mockShows, PageRequest.of(0, 10), 1);
 
             given(showRepository.getShowsResponse(Category.MUSICAL, "createdAt", "desc", PageRequest.of(0, 10)))
-                .willReturn(mockPage);
+                    .willReturn(mockPage);
 
             // when
             Page<ShowResponse> result = showQueryService.getShows(Category.MUSICAL, "createdAt", "desc", -1, 10);
@@ -255,7 +255,7 @@ class ShowQueryServiceTest {
             assertThat(result.getContent()).hasSize(1);
             assertThat(result.getTotalElements()).isEqualTo(1);
             verify(showRepository, times(1))
-                .getShowsResponse(Category.MUSICAL, "createdAt", "desc", PageRequest.of(0, 10));
+                    .getShowsResponse(Category.MUSICAL, "createdAt", "desc", PageRequest.of(0, 10));
         }
     }
 
@@ -270,9 +270,9 @@ class ShowQueryServiceTest {
             LocalDateTime reservationStart = now;
             LocalDateTime reservationEnd = now.plusDays(1);
 
-            Show show = Show.toEntity(1L, "제목1", "포스터1.jpg",
-                Category.MUSICAL, "내용1", "장소1",
-                reservationStart, reservationEnd, 2
+            Show show = Show.create(1L, "제목1", "포스터1.jpg",
+                    Category.MUSICAL, "내용1", "장소1",
+                    reservationStart, reservationEnd, 2
             );
             setCreatedAt(show, now);
             given(showRepository.findById(showId)).willReturn(Optional.of(show));
@@ -282,12 +282,12 @@ class ShowQueryServiceTest {
 
             // then
             assertThat(result)
-                .extracting("directorId", "title", "posterUrl", "category",
-                    "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
-                )
-                .containsExactly(1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
-                    reservationStart, reservationEnd, 2
-                );
+                    .extracting("directorId", "title", "posterUrl", "category",
+                            "description", "location", "reservationStart", "reservationEnd", "ticketsLimitPerUser"
+                    )
+                    .containsExactly(1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
+                            reservationStart, reservationEnd, 2
+                    );
             verify(showRepository, times(1)).findById(showId);
         }
 
@@ -299,8 +299,8 @@ class ShowQueryServiceTest {
 
             // when & then
             assertThatThrownBy(() -> showQueryService.getShow(showId))
-                .isInstanceOf(CustomException.class)
-                .hasMessage("해당 공연을 찾을 수 없습니다.");
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("해당 공연을 찾을 수 없습니다.");
 
         }
     }
@@ -313,18 +313,18 @@ class ShowQueryServiceTest {
             // given
             Long showId = 1L;
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
 
             LocalDateTime now = LocalDateTime.now();
             List<ShowDateDetailResponse> showDates = new ArrayList<>();
-            ShowDetailResponse response = ShowDetailResponse.toDto(
-                showId, 1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
-                now, now.plusDays(1), 2, 0, showDates, now, now
+            ShowDetailResponse response = ShowDetailResponse.of(
+                    showId, 1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
+                    now, now.plusDays(1), 2, 0, showDates, now, now
             );
 
             given(showRepository.getShowDetailResponseById(showId)).willReturn(Optional.of(response));
             given(showViewCountService.incrementViewCount(authUser, showId))
-                .willReturn(CompletableFuture.completedFuture(1));
+                    .willReturn(CompletableFuture.completedFuture(1));
 
             // when
             ShowDetailResponse result = showQueryService.getShow(authUser, showId);
@@ -344,14 +344,14 @@ class ShowQueryServiceTest {
 
             LocalDateTime now = LocalDateTime.now();
             List<ShowDateDetailResponse> showDates = new ArrayList<>();
-            ShowDetailResponse response = ShowDetailResponse.toDto(
-                showId, 1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
-                now, now.plusDays(1), 2, 0, showDates, now, now
+            ShowDetailResponse response = ShowDetailResponse.of(
+                    showId, 1L, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
+                    now, now.plusDays(1), 2, 0, showDates, now, now
             );
 
             given(showRepository.getShowDetailResponseById(showId)).willReturn(Optional.of(response));
             given(showViewCountService.incrementViewCount(authUser, showId))
-                .willReturn(CompletableFuture.completedFuture(null));
+                    .willReturn(CompletableFuture.completedFuture(null));
 
             // when
             ShowDetailResponse result = showQueryService.getShow(authUser, showId);
@@ -367,15 +367,15 @@ class ShowQueryServiceTest {
         void 공연_단건_조회_찾을_수_없는_공연_ID_예외() throws Exception {
             // given
             Long showId = -1L;
-            AuthUser authUser = AuthUser.toEntity(1L, UserRole.USER);
+            AuthUser authUser = AuthUser.create(1L, UserRole.USER);
 
             given(showRepository.getShowDetailResponseById(showId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> showQueryService.getShow(authUser, showId))
-                .isInstanceOf(CustomException.class)
-                .hasMessage("해당 공연을 찾을 수 없습니다.")
-                .satisfies(e -> assertThat(((CustomException) e).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("해당 공연을 찾을 수 없습니다.")
+                    .satisfies(e -> assertThat(((CustomException) e).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
             verify(showRepository, times(1)).getShowDetailResponseById(showId);
             verify(showViewCountService, times(0)).incrementViewCount(any(), any());
         }

--- a/src/test/java/com/example/picket/domain/show/service/ShowViewCountServiceTest.java
+++ b/src/test/java/com/example/picket/domain/show/service/ShowViewCountServiceTest.java
@@ -58,11 +58,11 @@ class ShowViewCountServiceTest {
         // given
         Long showId = 1L;
         Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+        AuthUser authUser = AuthUser.create(userId, UserRole.USER);
         String redisKey = String.format("view:show:%d:user:%d", showId, userId);
 
-        Show show = Show.toEntity(showId, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
-            LocalDateTime.now(), LocalDateTime.now().plusDays(1), 2);
+        Show show = Show.create(showId, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
+                LocalDateTime.now(), LocalDateTime.now().plusDays(1), 2);
         ReflectionTestUtils.setField(show, "viewCount", 0);
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
@@ -86,11 +86,11 @@ class ShowViewCountServiceTest {
         // given
         Long showId = 1L;
         Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+        AuthUser authUser = AuthUser.create(userId, UserRole.USER);
         String redisKey = String.format("view:show:%d:user:%d", showId, userId);
 
-        Show show = Show.toEntity(showId, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
-            LocalDateTime.now(), LocalDateTime.now().plusDays(1), 2);
+        Show show = Show.create(showId, "제목1", "포스터1.jpg", Category.MUSICAL, "내용1", "장소1",
+                LocalDateTime.now(), LocalDateTime.now().plusDays(1), 2);
         ReflectionTestUtils.setField(show, "viewCount", 0);
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
@@ -129,7 +129,7 @@ class ShowViewCountServiceTest {
         // given
         Long showId = 1L;
         Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+        AuthUser authUser = AuthUser.create(userId, UserRole.USER);
         String redisKey = String.format("view:show:%d:user:%d", showId, userId);
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
@@ -139,8 +139,8 @@ class ShowViewCountServiceTest {
 
         // when & then
         assertThatThrownBy(() -> showViewCountService.incrementViewCount(authUser, showId))
-            .isInstanceOf(CustomException.class)
-            .hasMessage("해당 공연을 찾을 수 없습니다.");
+                .isInstanceOf(CustomException.class)
+                .hasMessage("해당 공연을 찾을 수 없습니다.");
     }
 
     @Test
@@ -148,7 +148,7 @@ class ShowViewCountServiceTest {
         // given
         Long showId = 1L;
         Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+        AuthUser authUser = AuthUser.create(userId, UserRole.USER);
         String redisKey = String.format("view:show:%d:user:%d", showId, userId);
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
@@ -157,8 +157,8 @@ class ShowViewCountServiceTest {
 
         // when & then
         assertThatThrownBy(() -> showViewCountService.incrementViewCount(authUser, showId))
-            .isInstanceOf(RedisSystemException.class)
-            .hasMessage("Redis connection failed");
+                .isInstanceOf(RedisSystemException.class)
+                .hasMessage("Redis connection failed");
     }
 
 }

--- a/src/test/java/com/example/picket/domain/ticket/service/TicketCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/ticket/service/TicketCommandServiceTest.java
@@ -46,12 +46,12 @@ class TicketCommandServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = User.toEntity(
+        user = User.create(
                 "user@example.com", "encodedPw", UserRole.USER, null, "nickname",
                 LocalDate.of(1990, 1, 1), Gender.MALE
         );
 
-        show = Show.toEntity(
+        show = Show.create(
                 1L, "Show Title", "http://poster.url", Category.CONCERT, "Description",
                 "Location", LocalDateTime.now(), LocalDateTime.now().plusDays(1), 4
         );
@@ -103,7 +103,7 @@ class TicketCommandServiceTest {
 
     @Test
     void 티켓_삭제_시_본인이_예매하지_않은_티켓을_삭제하려_할_경우_예외가_발생한다() {
-        User anotherUser = User.toEntity(
+        User anotherUser = User.create(
                 "other@example.com", "pw", UserRole.USER, null, "other",
                 LocalDate.of(1991, 2, 2), Gender.FEMALE
         );
@@ -136,8 +136,6 @@ class TicketCommandServiceTest {
         assertEquals(HttpStatus.CONFLICT, exception.getStatus());
         assertEquals("이미 취소된 티켓입니다.", exception.getMessage());
     }
-
-
 
 
 }

--- a/src/test/java/com/example/picket/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/user/service/UserCommandServiceTest.java
@@ -1,28 +1,36 @@
 package com.example.picket.domain.user.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
+import com.example.picket.common.service.S3Service;
 import com.example.picket.config.PasswordEncoder;
+import com.example.picket.domain.images.dto.response.ImageResponse;
+import com.example.picket.domain.images.entity.UserImage;
+import com.example.picket.domain.images.repository.UserImageRepository;
 import com.example.picket.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.picket.domain.user.dto.request.UpdateUserRequest;
 import com.example.picket.domain.user.dto.request.WithdrawUserRequest;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserCommandServiceTest {
@@ -33,148 +41,223 @@ class UserCommandServiceTest {
     @Mock
     PasswordEncoder passwordEncoder;
 
+    @Mock
+    UserImageRepository userImageRepository;
+
+    @Mock
+    S3Service s3Service;
+
     @InjectMocks
     private UserCommandService userCommandService;
 
-    @Test
-    void 존재하지않는_사용자를_조회시_예외처리를_던진다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        UpdateUserRequest request = mock();
+    @Nested
+    class 유저_프로필_업데이트_테스트 {
+        @Test
+        void 존재하지않는_사용자를_조회시_예외처리를_던진다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            UpdateUserRequest request = mock();
 
-        BDDMockito.given(userRepository.findById(anyLong())).willReturn(Optional.empty());
-        // when & then
-        assertThrows(CustomException.class, () -> userCommandService.updateUser(authUser, request), "해당 유저를 찾을 수 없습니다."
-        );
+            given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+            // when & then
+            assertThrows(CustomException.class, () -> userCommandService.updateUser(authUser, request),
+                    "해당 유저를 찾을 수 없습니다."
+            );
+        }
+
+        @Test
+        void 유저정보_업데이트_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            UpdateUserRequest request = mock();
+            User user = mock();
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+            // when & then
+            assertThrows(CustomException.class, () -> userCommandService.updateUser(authUser, request),
+                    "비밀번호가 일치하지 않습니다.");
+        }
+
+        @Test
+        void 사용자가_프로필을_변경할_수_있다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            UpdateUserRequest request = new UpdateUserRequest();
+            ReflectionTestUtils.setField(request, "password", "test");
+            ReflectionTestUtils.setField(request, "nickname", "test");
+            ReflectionTestUtils.setField(request, "profileUrl", "newProfileUrl");
+
+            User user = mock(User.class);
+            UserImage userImage = mock(UserImage.class);
+            given(user.getPassword()).willReturn("test");
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches("test", "test")).willReturn(true);
+            given(userImageRepository.findByImageUrl(any())).willReturn(Optional.of(userImage));
+
+            // when
+            User response = userCommandService.updateUser(authUser, request);
+
+            // then
+            assertThat(response).isNotNull();
+            verify(user).update("test", "newProfileUrl");
+        }
+
+        @Test
+        void 사용자가_프로필을_변경시_기존_프로필_이미지가_존재한다면_제거하고_변경할_수_있다() {
+            // given
+            AuthUser authUser = mock(AuthUser.class);
+            UpdateUserRequest request = mock(UpdateUserRequest.class);
+            User user = mock(User.class);
+            UserImage userImage = mock(UserImage.class);
+
+            String existingProfileUrl = "https://example.com/old-image.jpg";
+            String newProfileUrl = "https://example.com/new-image.jpg";
+            String nickname = "newNickname";
+
+            given(authUser.getId()).willReturn(1L);
+            given(request.getPassword()).willReturn("password");
+            given(request.getProfileUrl()).willReturn(newProfileUrl);
+            given(request.getNickname()).willReturn(nickname);
+
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(any(), any())).willReturn(true);
+            given(userImageRepository.findByImageUrl(any())).willReturn(Optional.of(userImage));
+            given(user.getProfileUrl()).willReturn(existingProfileUrl);
+
+            doNothing().when(userImage).updateUser(anyLong());
+            doNothing().when(user).update(any(), any());
+            doNothing().when(s3Service).delete(any());
+
+            // when
+            User response = userCommandService.updateUser(authUser, request);
+
+            // then
+            assertThat(response).isNotNull();
+            verify(userRepository, times(1)).findById(anyLong());
+            verify(passwordEncoder, times(1)).matches(any(), any());
+            verify(userImageRepository, times(2)).findByImageUrl(any());
+            verify(userImage, times(1)).updateUser(anyLong());
+            verify(s3Service, times(1)).delete(existingProfileUrl);
+            verify(user, times(1)).update(nickname, newProfileUrl);
+        }
     }
 
-    @Test
-    void 유저정보_업데이트_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        UpdateUserRequest request = mock();
-        User user = mock();
-        BDDMockito.given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        // when & then
-        assertThrows(CustomException.class, () -> userCommandService.updateUser(authUser, request),
-                "비밀번호가 일치하지 않습니다.");
+    @Nested
+    class 유저_비밀번호_업데이트_테스트 {
+        @Test
+        void 비밀번호_업데이트_시_존재하지_않는_사용자를_조회하면_예외처리를_던진다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            UpdatePasswordRequest request = mock();
+
+            given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+            // when & then
+            assertThrows(CustomException.class, () -> userCommandService.updatePassword(authUser, request),
+                    "해당 유저를 찾을 수 없습니다."
+            );
+        }
+
+        @Test
+        void 비밀번호_업데이트_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            UpdatePasswordRequest request = mock();
+            User user = mock();
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+            // when & then
+            assertThrows(CustomException.class, () -> userCommandService.updatePassword(authUser, request),
+                    "비밀번호가 일치하지 않습니다.");
+        }
+
+        @Test
+        void 사용자의_비밀번호를_변경할_수_있다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            UpdatePasswordRequest request = new UpdatePasswordRequest();
+            ReflectionTestUtils.setField(request, "password", "test");
+            ReflectionTestUtils.setField(request, "newPassword", "test2");
+
+            User user = mock(User.class);
+            given(user.getPassword()).willReturn("test");
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches("test", "test")).willReturn(true);
+            given(passwordEncoder.encode("test2")).willReturn("test2");
+
+            // when
+            userCommandService.updatePassword(authUser, request);
+
+            // then
+            verify(user).passwordUpdate("test2");
+        }
     }
 
-    @Test
-    void 사용자가_프로필을_변경할_수_있다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        UpdateUserRequest request = new UpdateUserRequest();
-        ReflectionTestUtils.setField(request, "password", "test");
-        ReflectionTestUtils.setField(request, "nickname", "test");
-        ReflectionTestUtils.setField(request, "profileUrl", "newProfileUrl");
+    @Nested
+    class 유저_탈퇴_테스트 {
+        @Test
+        void 유저탈퇴_시_존재하지_않는_사용자를_조회하면_예외처리를_던진다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            WithdrawUserRequest request = mock();
 
-        User user = mock(User.class);
-        BDDMockito.given(user.getPassword()).willReturn("test");
-        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        BDDMockito.given(passwordEncoder.matches("test", "test")).willReturn(true);
+            given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+            // when & then
+            assertThrows(CustomException.class, () -> userCommandService.withdrawUserRequest(authUser, request),
+                    "해당 유저를 찾을 수 없습니다."
+            );
+        }
 
-        // when
-        User response = userCommandService.updateUser(authUser, request);
+        @Test
+        void 유저탈퇴_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            WithdrawUserRequest request = mock();
+            User user = mock();
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+            // when & then
+            assertThrows(CustomException.class, () -> userCommandService.withdrawUserRequest(authUser, request),
+                    "비밀번호가 일치하지 않습니다.");
+        }
 
-        // then
-        assertThat(response).isNotNull();
-        verify(user).update("test", "newProfileUrl");
+        @Test
+        void 사용자는_탈퇴를_할_수_있다() {
+            // given
+            Long userId = 1L;
+            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            User user = mock(User.class);
+            WithdrawUserRequest request = new WithdrawUserRequest();
+            ReflectionTestUtils.setField(request, "password", "test");
+
+            given(user.getPassword()).willReturn("test");
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(request.getPassword(), "test")).willReturn(true);
+            // when
+            userCommandService.withdrawUserRequest(authUser, request);
+            // then
+            verify(userRepository, times(1)).delete(user);
+        }
     }
 
-    @Test
-    void 비밀번호_업데이트_시_존재하지_않는_사용자를_조회하면_예외처리를_던진다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        UpdatePasswordRequest request = mock();
-
-        BDDMockito.given(userRepository.findById(anyLong())).willReturn(Optional.empty());
-        // when & then
-        assertThrows(CustomException.class, () -> userCommandService.updatePassword(authUser, request), "해당 유저를 찾을 수 없습니다."
-        );
+    @Nested
+    class 유저_이미지_테스트 {
+        @Test
+        void 유저_포스터_이미지_생성_성공() {
+            // given
+            ImageResponse imageResponse = mock(ImageResponse.class);
+            UserImage userImage = mock(UserImage.class);
+            given(s3Service.upload(any(), anyLong(), any())).willReturn(imageResponse);
+            given(userImageRepository.save(any())).willReturn(userImage);
+            // when
+            userCommandService.uploadImage(any(), anyLong(), any());
+            // then
+            verify(s3Service, times(1)).upload(any(), anyLong(), any());
+            verify(userImageRepository, times(1)).save(any());
+        }
     }
-
-    @Test
-    void 비밀번호_업데이트_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        UpdatePasswordRequest request = mock();
-        User user = mock();
-        BDDMockito.given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        // when & then
-        assertThrows(CustomException.class, () -> userCommandService.updatePassword(authUser, request),
-                "비밀번호가 일치하지 않습니다.");
-    }
-
-    @Test
-    void 사용자의_비밀번호를_변경할_수_있다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        UpdatePasswordRequest request = new UpdatePasswordRequest();
-        ReflectionTestUtils.setField(request, "password", "test");
-        ReflectionTestUtils.setField(request, "newPassword", "test2");
-
-        User user = mock(User.class);
-        BDDMockito.given(user.getPassword()).willReturn("test");
-        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        BDDMockito.given(passwordEncoder.matches("test", "test")).willReturn(true);
-        BDDMockito.given(passwordEncoder.encode("test2")).willReturn("test2");
-
-        // when
-        userCommandService.updatePassword(authUser, request);
-
-        // then
-        verify(user).passwordUpdate("test2");
-    }
-
-    @Test
-    void 유저탈퇴_시_존재하지_않는_사용자를_조회하면_예외처리를_던진다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        WithdrawUserRequest request = mock();
-
-        BDDMockito.given(userRepository.findById(anyLong())).willReturn(Optional.empty());
-        // when & then
-        assertThrows(CustomException.class, () -> userCommandService.withdrawUserRequest(authUser, request), "해당 유저를 찾을 수 없습니다."
-        );
-    }
-
-    @Test
-    void 유저탈퇴_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        WithdrawUserRequest request = mock();
-        User user = mock();
-        BDDMockito.given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        // when & then
-        assertThrows(CustomException.class, () -> userCommandService.withdrawUserRequest(authUser, request),
-                "비밀번호가 일치하지 않습니다.");
-    }
-
-    @Test
-    void 사용자는_탈퇴를_할_수_있다() {
-        // given
-        Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
-        User user = mock(User.class);
-        WithdrawUserRequest request = new WithdrawUserRequest();
-        ReflectionTestUtils.setField(request, "password", "test");
-
-        BDDMockito.given(user.getPassword()).willReturn("test");
-        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        BDDMockito.given(passwordEncoder.matches(request.getPassword(), "test")).willReturn(true);
-        // when
-        userCommandService.withdrawUserRequest(authUser, request);
-        // then
-        verify(userRepository, times(1)).delete(user);
-    }
-
 }

--- a/src/test/java/com/example/picket/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/user/service/UserCommandServiceTest.java
@@ -233,10 +233,13 @@ class UserCommandServiceTest {
             User user = mock(User.class);
             WithdrawUserRequest request = new WithdrawUserRequest();
             ReflectionTestUtils.setField(request, "password", "test");
+            UserImage userImage = mock(UserImage.class);
 
             given(user.getPassword()).willReturn("test");
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(passwordEncoder.matches(request.getPassword(), "test")).willReturn(true);
+            given(userImageRepository.findByImageUrl(any())).willReturn(Optional.of(userImage));
+            doNothing().when(userImageRepository).delete(any());
             // when
             userCommandService.withdrawUserRequest(authUser, request);
             // then

--- a/src/test/java/com/example/picket/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/user/service/UserCommandServiceTest.java
@@ -1,15 +1,5 @@
 package com.example.picket.domain.user.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
@@ -23,7 +13,6 @@ import com.example.picket.domain.user.dto.request.UpdateUserRequest;
 import com.example.picket.domain.user.dto.request.WithdrawUserRequest;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.repository.UserRepository;
-import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +20,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserCommandServiceTest {
@@ -56,7 +54,7 @@ class UserCommandServiceTest {
         void 존재하지않는_사용자를_조회시_예외처리를_던진다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             UpdateUserRequest request = mock();
 
             given(userRepository.findById(anyLong())).willReturn(Optional.empty());
@@ -70,7 +68,7 @@ class UserCommandServiceTest {
         void 유저정보_업데이트_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             UpdateUserRequest request = mock();
             User user = mock();
             given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
@@ -83,7 +81,7 @@ class UserCommandServiceTest {
         void 사용자가_프로필을_변경할_수_있다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             UpdateUserRequest request = new UpdateUserRequest();
             ReflectionTestUtils.setField(request, "password", "test");
             ReflectionTestUtils.setField(request, "nickname", "test");
@@ -150,7 +148,7 @@ class UserCommandServiceTest {
         void 비밀번호_업데이트_시_존재하지_않는_사용자를_조회하면_예외처리를_던진다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             UpdatePasswordRequest request = mock();
 
             given(userRepository.findById(anyLong())).willReturn(Optional.empty());
@@ -164,7 +162,7 @@ class UserCommandServiceTest {
         void 비밀번호_업데이트_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             UpdatePasswordRequest request = mock();
             User user = mock();
             given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
@@ -177,7 +175,7 @@ class UserCommandServiceTest {
         void 사용자의_비밀번호를_변경할_수_있다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             UpdatePasswordRequest request = new UpdatePasswordRequest();
             ReflectionTestUtils.setField(request, "password", "test");
             ReflectionTestUtils.setField(request, "newPassword", "test2");
@@ -202,7 +200,7 @@ class UserCommandServiceTest {
         void 유저탈퇴_시_존재하지_않는_사용자를_조회하면_예외처리를_던진다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             WithdrawUserRequest request = mock();
 
             given(userRepository.findById(anyLong())).willReturn(Optional.empty());
@@ -216,7 +214,7 @@ class UserCommandServiceTest {
         void 유저탈퇴_시_입력한_비밀번호가_잘못되면_예외처리를_던진다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             WithdrawUserRequest request = mock();
             User user = mock();
             given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
@@ -229,7 +227,7 @@ class UserCommandServiceTest {
         void 사용자는_탈퇴를_할_수_있다() {
             // given
             Long userId = 1L;
-            AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+            AuthUser authUser = AuthUser.create(userId, UserRole.USER);
             User user = mock(User.class);
             WithdrawUserRequest request = new WithdrawUserRequest();
             ReflectionTestUtils.setField(request, "password", "test");

--- a/src/test/java/com/example/picket/domain/user/service/UserQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/user/service/UserQueryServiceTest.java
@@ -1,13 +1,5 @@
 package com.example.picket.domain.user.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.UserRole;
@@ -15,16 +7,23 @@ import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.user.dto.response.UserResponse;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.repository.UserRepository;
-
-import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class UserQueryServiceTest {
@@ -39,7 +38,7 @@ class UserQueryServiceTest {
     void 존재하지않는_사용자를_조회시_예외처리를_던진다() {
         // given
         Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+        AuthUser authUser = AuthUser.create(userId, UserRole.USER);
 
         given(userRepository.findById(anyLong())).willReturn(Optional.empty());
         // when & then
@@ -50,7 +49,7 @@ class UserQueryServiceTest {
     void 사용자를_조회한다() {
         // given
         Long userId = 1L;
-        AuthUser authUser = AuthUser.toEntity(userId, UserRole.USER);
+        AuthUser authUser = AuthUser.create(userId, UserRole.USER);
         User user = mock();
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         // when
@@ -118,11 +117,11 @@ class UserQueryServiceTest {
     }
 
     private User createUser(Long userId) {
-        User user = User.toEntity("user@example.com"
-                ,"test123!"
+        User user = User.create("user@example.com"
+                , "test123!"
                 , UserRole.USER
-                ,null
-                ,"닉네임"
+                , null
+                , "닉네임"
                 , LocalDate.parse("1990-06-25")
                 , Gender.FEMALE);
 


### PR DESCRIPTION
📌 반영 브랜치
feat/image -> dev

✅ 작업 내용
- UserImage, ShowImage 엔티티 생성(UserImage에는 유저 프로필 이미지, ShowImage에는 공연 포스터 이미지 저장)
- S3 생성 및 연결
- 각 이미지 업로드 메서드 컨트롤러 구현
- 이미지 업로드 시에는 연관된 ID 값이 존재하지 않고,
	- 유저 수정 시에 ID 값 업데이트
	- 공연 생성 및 수정 시에 ID 값 업데이트
- 유저 프로필 이미지, 공연 포스터가 업데이트 될 때, 기존 이미지는 삭제
- 유저 탈퇴, 공연 삭제 시에도 연관된 이미지는 삭제
- 고아 객체 관리 위한 Scheduler 생성
	- 이미지가 생성된지 하루가 지났고, 연관된 ID 가 null인 경우 삭제(유저, 공연 이미지)
	- 삭제시 쿼리 통하여 하나의 쿼리로 삭제 가능하도록 수정

🎯 단독 테스트 결과
- 단위 테스트 TestCode 통해 확인
- PostMan 통해 통합 테스트 확인 완료
- Swagger는 작성이 애매해서 일단 보류해두었습니다!

🚨 연관 이슈
closes #115 
closes #116 
closes #119 