### PR TITLE
AWS SES: 회원가입 시 이메일 인증코드 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,10 @@ dependencies {
     // AWS
     implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
 
+    // AWS SES
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'software.amazon.awssdk:ses:2.29.46'
+
     // S3
     implementation "software.amazon.awssdk:s3:2.31.0"
 

--- a/src/main/java/com/example/picket/common/consts/Const.java
+++ b/src/main/java/com/example/picket/common/consts/Const.java
@@ -21,8 +21,9 @@ public interface Const {
             "POST", new String[]{
                     "/api/v*/auth/signup/*",
                     "/api/v*/auth/signin",
+                    "/api/v*/auth/verify-code",
                     "/swagger-ui/*",
-                    "/v3/api-docs/**"
+                    "/v3/api-docs/**",
             },
             "PUT", new String[]{
 

--- a/src/main/java/com/example/picket/config/EmailConfig.java
+++ b/src/main/java/com/example/picket/config/EmailConfig.java
@@ -1,0 +1,30 @@
+package com.example.picket.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ses.SesClient;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${aws.ses.access-key}")
+    private String accessKey;
+    @Value("${aws.ses.secret-key}")
+    private String secretKey;
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public SesClient amazonSimpleEmailService() {
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return SesClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/example/picket/config/TemplateConfig.java
+++ b/src/main/java/com/example/picket/config/TemplateConfig.java
@@ -1,0 +1,18 @@
+package com.example.picket.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
+
+@Configuration
+public class TemplateConfig {
+
+    @Bean
+    public TemplateEngine htmlTemplateEngine(SpringResourceTemplateResolver springResourceTemplateResolver) {
+        TemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(springResourceTemplateResolver);
+        return templateEngine;
+    }
+}

--- a/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
@@ -32,18 +32,6 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "이메일 인증 코드 발송", description = "회원가입 정보 입력 후 이메일로 인증 코드를 발송합니다.")
-    @PostMapping("/auth/send-verification")
-    public ResponseEntity<?> sendVerificationCode(@Valid @RequestBody VerifyCodeRequest request) {
-        try {
-            authService.sendVerificationCode(request.getEmail());
-            return new ResponseEntity<>(HttpStatus.OK);
-        } catch (CustomException e) {
-            return ResponseEntity.status(e.getStatus())
-                    .body(Map.of("message", e.getMessage()));
-        }
-    }
-
     @Operation(summary = "회원가입 정보 입력", description = "유저 역할을 가진 회원가입 정보를 입력합니다. 회원가입은 이메일 인증 후 완료됩니다.")
     @PostMapping("/auth/signup/user")
     public ResponseEntity<SignupResponse> signupUser(@Valid @RequestBody SignupRequest request) {

--- a/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
@@ -1,12 +1,11 @@
 package com.example.picket.domain.auth.controller;
 
 import com.example.picket.common.enums.UserRole;
-import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.auth.dto.request.SigninRequest;
 import com.example.picket.domain.auth.dto.request.SignupRequest;
 import com.example.picket.domain.auth.dto.request.VerifyCodeRequest;
-import com.example.picket.domain.auth.dto.response.SignupResponse;
 import com.example.picket.domain.auth.dto.response.SigninResponse;
+import com.example.picket.domain.auth.dto.response.SignupResponse;
 import com.example.picket.domain.auth.service.AuthService;
 import com.example.picket.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,11 +21,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v2")
 @Tag(name = "인증/인가 API", description = "회원가입, 로그인, 로그아웃 API입니다.")
 public class AuthController {
 

--- a/src/main/java/com/example/picket/domain/auth/dto/request/EmailVerificationRequest.java
+++ b/src/main/java/com/example/picket/domain/auth/dto/request/EmailVerificationRequest.java
@@ -1,0 +1,13 @@
+package com.example.picket.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailVerificationRequest {
+
+    @Email(message = "유효한 이메일 형식이어야 합니다.")
+    private String email;
+}

--- a/src/main/java/com/example/picket/domain/auth/dto/request/VerifyCodeRequest.java
+++ b/src/main/java/com/example/picket/domain/auth/dto/request/VerifyCodeRequest.java
@@ -1,0 +1,17 @@
+package com.example.picket.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VerifyCodeRequest {
+
+    @Email(message = "유효한 이메일 형식이어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "인증 코드는 필수입니다.")
+    private String verificationCode;
+}

--- a/src/main/java/com/example/picket/domain/auth/dto/response/SignupResponse.java
+++ b/src/main/java/com/example/picket/domain/auth/dto/response/SignupResponse.java
@@ -1,0 +1,11 @@
+package com.example.picket.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupResponse {
+    private String tempUserId;
+    private String email;
+}

--- a/src/main/java/com/example/picket/domain/auth/entity/TempUserData.java
+++ b/src/main/java/com/example/picket/domain/auth/entity/TempUserData.java
@@ -1,0 +1,19 @@
+package com.example.picket.domain.auth.entity;
+
+import com.example.picket.common.enums.Gender;
+import com.example.picket.common.enums.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class TempUserData {
+    private String email;
+    private String password;  // 인코딩된 비밀번호
+    private String nickname;
+    private LocalDate birth;
+    private Gender gender;
+    private UserRole userRole;
+}

--- a/src/main/java/com/example/picket/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/picket/domain/auth/service/AuthService.java
@@ -5,16 +5,21 @@ import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.config.PasswordEncoder;
+import com.example.picket.domain.auth.entity.TempUserData;
+import com.example.picket.domain.email.service.EmailService;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -25,17 +30,107 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
+    private final StringRedisTemplate redisTemplate;
 
-    public void signup(String email, String password, String nickname, LocalDate birth, Gender gender,
-                       UserRole userRole) {
-
+    // 회원가입 정보 등록 (이메일 인증 전)
+    public String registerUserInfo(String email, String password, String nickname, LocalDate birth,
+                                   Gender gender, UserRole userRole) {
+        // 이미 가입된 이메일인지 확인
         if (userRepository.existsByEmail(email)) {
-            throw new CustomException(BAD_REQUEST, "이미 가입되어있는 이메일 입니다.");
+            throw new CustomException(BAD_REQUEST, "이미 가입되어있는 이메일입니다.");
         }
 
-        User newUser = User.create(email, passwordEncoder.encode(password), userRole, null, nickname, birth, gender);
+        // 임시 사용자 ID 생성
+        String tempUserId = UUID.randomUUID().toString();
 
-        userRepository.save(newUser);
+        // 임시 사용자 정보를 Redis에 저장 (30분 유효)
+        TempUserData tempUserData = new TempUserData(email, passwordEncoder.encode(password),
+                nickname, birth, gender, userRole);
+
+        // Redis에 임시 사용자 정보 저장
+        String tempUserKey = "tempUser:" + tempUserId;
+        redisTemplate.opsForHash().put(tempUserKey, "email", email);
+        redisTemplate.opsForHash().put(tempUserKey, "password", tempUserData.getPassword());
+        redisTemplate.opsForHash().put(tempUserKey, "nickname", nickname);
+        redisTemplate.opsForHash().put(tempUserKey, "birth", birth.toString());
+        redisTemplate.opsForHash().put(tempUserKey, "gender", gender.toString());
+        redisTemplate.opsForHash().put(tempUserKey, "userRole", userRole.toString());
+        redisTemplate.expire(tempUserKey, 30, TimeUnit.MINUTES);
+
+        // 이메일-임시ID 매핑 저장
+        redisTemplate.opsForValue().set("email2tempId:" + email, tempUserId, 30, TimeUnit.MINUTES);
+
+        // 이메일 인증 코드 발송
+        emailService.sendVerificationEmail(email);
+
+        return tempUserId;
+    }
+
+    // 이메일 인증 코드 발송
+    public void sendVerificationCode(String email) {
+        // 이미 가입된 이메일인지 확인
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(BAD_REQUEST, "이미 가입되어있는 이메일입니다.");
+        }
+
+        // 회원가입 정보가 없는 경우 에러
+        String tempUserId = redisTemplate.opsForValue().get("email2tempId:" + email);
+        if (tempUserId == null) {
+            throw new CustomException(BAD_REQUEST, "먼저 회원가입 정보를 입력해주세요.");
+        }
+
+        try {
+            // 이메일 인증 코드 발송
+            emailService.sendVerificationEmail(email);
+        } catch (CustomException e) {
+            throw e;
+        }
+    }
+
+    // 이메일 인증 코드 검증 및 회원가입 완료
+    public boolean verifyCodeAndCompleteSignup(String email, String code) {
+        // 인증 코드 검증
+        boolean isVerified = emailService.verifyCode(email, code);
+
+        if (isVerified) {
+            // 임시 사용자 ID 조회
+            String tempUserId = redisTemplate.opsForValue().get("email2tempId:" + email);
+            if (tempUserId == null) {
+                throw new CustomException(BAD_REQUEST, "회원가입 정보가 만료되었습니다. 다시 시도해주세요.");
+            }
+
+            // 임시 사용자 정보 조회
+            String tempUserKey = "tempUser:" + tempUserId;
+            String storedEmail = (String) redisTemplate.opsForHash().get(tempUserKey, "email");
+            String password = (String) redisTemplate.opsForHash().get(tempUserKey, "password");
+            String nickname = (String) redisTemplate.opsForHash().get(tempUserKey, "nickname");
+            String birthStr = (String) redisTemplate.opsForHash().get(tempUserKey, "birth");
+            String genderStr = (String) redisTemplate.opsForHash().get(tempUserKey, "gender");
+            String userRoleStr = (String) redisTemplate.opsForHash().get(tempUserKey, "userRole");
+
+            if (storedEmail == null || !storedEmail.equals(email)) {
+                throw new CustomException(BAD_REQUEST, "회원정보가 일치하지 않습니다.");
+            }
+
+            LocalDate birth = LocalDate.parse(birthStr);
+            Gender gender = Gender.valueOf(genderStr);
+            UserRole userRole = UserRole.valueOf(userRoleStr);
+
+            // 사용자 생성 및 저장
+            User newUser = User.create(email, password, userRole, null, nickname, birth, gender);
+            userRepository.save(newUser);
+
+            // Redis에서 임시 정보 삭제
+            redisTemplate.delete(tempUserKey);
+            redisTemplate.delete("email2tempId:" + email);
+            redisTemplate.delete("verification:" + email);
+            redisTemplate.delete("verified:" + email);
+
+            return true;
+        }
+
+        return false;
     }
 
     public User signin(HttpSession session, HttpServletResponse response, String email, String password) {

--- a/src/main/java/com/example/picket/domain/email/controller/EmailController.java
+++ b/src/main/java/com/example/picket/domain/email/controller/EmailController.java
@@ -1,0 +1,36 @@
+package com.example.picket.domain.email.controller;
+
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.email.dto.request.EmailResendRequest;
+import com.example.picket.domain.email.service.EmailService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/email")
+@Tag(name = "이메일 API", description = "이메일 전송 및 재시도 관련 API입니다.")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @Operation(summary = "인증 이메일 재전송", description = "인증 코드를 이메일로 다시 전송합니다.")
+    @PostMapping("/resend")
+    public ResponseEntity<?> resendVerificationEmail(@Valid @RequestBody EmailResendRequest request) {
+        try {
+            emailService.sendVerificationEmail(request.getEmail());
+            return new ResponseEntity<>(HttpStatus.OK);
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getStatus())
+                    .body(Map.of("message", e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/example/picket/domain/email/controller/EmailController.java
+++ b/src/main/java/com/example/picket/domain/email/controller/EmailController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,12 +26,12 @@ public class EmailController {
     @Operation(summary = "인증 이메일 재전송", description = "인증 코드를 이메일로 다시 전송합니다.")
     @PostMapping("/resend")
     public ResponseEntity<?> resendVerificationEmail(@Valid @RequestBody EmailResendRequest request) {
-        try {
-            emailService.sendVerificationEmail(request.getEmail());
-            return new ResponseEntity<>(HttpStatus.OK);
-        } catch (CustomException e) {
-            return ResponseEntity.status(e.getStatus())
-                    .body(Map.of("message", e.getMessage()));
-        }
+        return Optional.ofNullable(request.getEmail())
+                .map(email -> {
+                    emailService.sendVerificationEmail(email);
+                    return new ResponseEntity<>(HttpStatus.OK);
+                })
+                .orElseGet(() -> ResponseEntity.badRequest()
+                        .body(Map.of("message", "이메일 정보가 필요합니다.")));
     }
 }

--- a/src/main/java/com/example/picket/domain/email/dto/request/EmailResendRequest.java
+++ b/src/main/java/com/example/picket/domain/email/dto/request/EmailResendRequest.java
@@ -1,0 +1,15 @@
+package com.example.picket.domain.email.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailResendRequest {
+
+    @Email(message = "유효한 이메일 형식이어야 합니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+}

--- a/src/main/java/com/example/picket/domain/email/entity/EmailInfo.java
+++ b/src/main/java/com/example/picket/domain/email/entity/EmailInfo.java
@@ -1,0 +1,49 @@
+package com.example.picket.domain.email.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.ses.model.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailInfo {
+
+    private String from;
+    private List<String> to;
+    private String subject;
+    private String content;
+
+    public EmailInfo(String from, List<String> to, String subject, String content) {
+        this.from = from;
+        this.to = to;
+        this.subject = subject;
+        this.content = content;
+    }
+
+    public SendEmailRequest toSendEmailRequest() {
+        Destination destination = Destination.builder()
+                .toAddresses(this.to)
+                .build();
+
+        Message message = Message.builder()
+                .subject(createContent(this.subject))
+                .body(Body.builder().html(createContent(this.content)).build())
+                .build();
+
+        return SendEmailRequest.builder()
+                .source(this.from)
+                .destination(destination)
+                .message(message)
+                .build();
+    }
+
+    private Content createContent(String text) {
+        return Content.builder()
+                .charset("UTF-8")
+                .data(text)
+                .build();
+    }
+}

--- a/src/main/java/com/example/picket/domain/email/service/EmailService.java
+++ b/src/main/java/com/example/picket/domain/email/service/EmailService.java
@@ -1,0 +1,81 @@
+package com.example.picket.domain.email.service;
+
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.email.entity.EmailInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.SendEmailRequest;
+import software.amazon.awssdk.services.ses.model.SesException;
+
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    @Value("${aws.ses.send-mail-from}")
+    private String sender;
+    private final SesClient sesClient;
+    private final TemplateEngine templateEngine;
+    private final StringRedisTemplate redisTemplate;
+
+    private String generateVerificationCode() {
+        SecureRandom random = new SecureRandom();
+        int code = 100000 + random.nextInt(900000); // 100000 ~ 999999
+        return String.valueOf(code);
+    }
+
+    // 인증 코드 메일 발송
+    public String sendVerificationEmail(String recipientEmail) {
+        String verificationCode = generateVerificationCode();
+
+        // Redis에 인증 코드 저장 (5분 TTL)
+        redisTemplate.opsForValue().set(
+                "verification:" + recipientEmail,
+                verificationCode,
+                5,
+                TimeUnit.MINUTES
+        );
+
+        Context context = new Context();
+        context.setVariable("verificationCode", verificationCode);
+
+        String content = templateEngine.process("verification-email", context);
+
+        EmailInfo emailInfo = new EmailInfo(
+                sender,
+                Collections.singletonList(recipientEmail),
+                "회원가입 인증 코드",
+                content
+        );
+
+        try {
+            SendEmailRequest request = emailInfo.toSendEmailRequest();
+            sesClient.sendEmail(request);
+            return verificationCode;
+        } catch (SesException e) {
+            throw new CustomException(INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.");
+        }
+    }
+
+    // 인증 코드 검증
+    public boolean verifyCode(String email, String code) {
+        String storedCode = redisTemplate.opsForValue().get("verification:" + email);
+
+        if (storedCode != null && storedCode.equals(code)) {
+            redisTemplate.opsForValue().set("verified:" + email, "true", 30, TimeUnit.MINUTES);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,3 +55,10 @@ cloud:
       static: ${AWS_REGION}
     stack:
       auto: false
+
+aws:
+  region: ${AWS_REGION}
+  ses:
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}
+    send-mail-from: ${ADMIN_EMAIL}

--- a/src/main/resources/templates/verification-email.html
+++ b/src/main/resources/templates/verification-email.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>회원가입 인증 코드</title>
+</head>
+<body>
+<h1>🎉 회원가입 인증 코드</h1>
+<p>아래 인증 코드를 입력하여 회원가입을 완료하세요.</p>
+<h2 th:text="${verificationCode}">123456</h2>
+<p>이 코드는 5분 동안 유효합니다.</p>
+</body>
+</html>

--- a/src/test/java/com/example/picket/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/picket/domain/auth/service/AuthServiceTest.java
@@ -5,8 +5,10 @@ import com.example.picket.common.enums.Gender;
 import com.example.picket.common.enums.UserRole;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.config.PasswordEncoder;
+import com.example.picket.domain.email.service.EmailService;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.Nested;
@@ -16,18 +18,23 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -37,6 +44,18 @@ class AuthServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
 
     @Mock
     private HttpSession session;
@@ -53,18 +72,18 @@ class AuthServiceTest {
         @Test
         void 회원가입_시_존재하는_이메일로_회원가입_시도_할_경우_실패() {
             // given
-            String alreadyExistEmail = "test@example.com";
+            String email = "test@example.com";
             String password = "!Password1234";
             String nickname = "nickname1";
             LocalDate birth = LocalDate.of(2000, 12, 12);
             Gender gender = Gender.MALE;
             UserRole userRole = UserRole.USER;
-            given(userRepository.existsByEmail(any())).willReturn(true);
+            given(userRepository.existsByEmail(email)).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> authService.signup(alreadyExistEmail, password, nickname, birth, gender, userRole))
+            assertThatThrownBy(() -> authService.registerUserInfo(email, password, nickname, birth, gender, userRole))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage("이미 가입되어있는 이메일 입니다.");
+                    .hasMessage("이미 가입되어있는 이메일입니다.");
         }
 
         @Test
@@ -76,15 +95,118 @@ class AuthServiceTest {
             LocalDate birth = LocalDate.of(2000, 12, 12);
             Gender gender = Gender.MALE;
             UserRole userRole = UserRole.USER;
-            given(userRepository.existsByEmail(any())).willReturn(false);
+            String encodedPassword = "encodedPassword";
+
+            given(userRepository.existsByEmail(email)).willReturn(false);
+            given(passwordEncoder.encode(password)).willReturn(encodedPassword);
+            given(redisTemplate.opsForHash()).willReturn(hashOperations);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
             // when
-            authService.signup(email, password, nickname, birth, gender, userRole);
+            String tempUserId = authService.registerUserInfo(email, password, nickname, birth, gender, userRole);
 
             // then
-            verify(userRepository, times(1)).existsByEmail(email);
-            verify(passwordEncoder, times(1)).encode(password);
-            verify(userRepository, times(1)).save(any(User.class));
+            verify(userRepository).existsByEmail(email);
+            verify(passwordEncoder).encode(password);
+            verify(hashOperations, times(6)).put(anyString(), any(), any());
+            verify(redisTemplate).expire(anyString(), eq(30L), eq(TimeUnit.MINUTES));
+            verify(valueOperations).set(anyString(), anyString(), eq(30L), eq(TimeUnit.MINUTES));
+            verify(emailService).sendVerificationEmail(email);
+            assertThat(tempUserId).isNotNull();
+        }
+    }
+
+    @Nested
+    class 이메일_인증_코드_검증_테스트 {
+
+        @Test
+        void 인증_코드_검증_실패() {
+            // given
+            String email = "test@example.com";
+            String code = "123456";
+            given(emailService.verifyCode(email, code)).willReturn(false);
+
+            // when
+            boolean result = authService.verifyCodeAndCompleteSignup(email, code);
+
+            // then
+            assertThat(result).isFalse();
+            verify(emailService).verifyCode(email, code);
+            verifyNoMoreInteractions(redisTemplate);
+        }
+
+        @Test
+        void 인증_코드_검증_성공_임시_사용자_ID_없음() {
+            // given
+            String email = "test@example.com";
+            String code = "123456";
+            given(emailService.verifyCode(email, code)).willReturn(true);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get("email2tempId:" + email)).willReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifyCodeAndCompleteSignup(email, code))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("회원가입 정보가 만료되었습니다. 다시 시도해주세요.");
+        }
+
+        @Test
+        void 인증_코드_검증_성공_이메일_불일치() {
+            // given
+            String email = "test@example.com";
+            String code = "123456";
+            String tempUserId = "temp-user-id";
+            String tempUserKey = "tempUser:" + tempUserId;
+
+            given(emailService.verifyCode(email, code)).willReturn(true);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get("email2tempId:" + email)).willReturn(tempUserId);
+            given(redisTemplate.opsForHash()).willReturn(hashOperations);
+
+            Map<Object, Object> userDataMap = new HashMap<>();
+            userDataMap.put("email", "different@example.com");
+            given(hashOperations.entries(tempUserKey)).willReturn(userDataMap);
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifyCodeAndCompleteSignup(email, code))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("회원정보가 일치하지 않습니다.");
+        }
+
+        @Test
+        void 인증_코드_검증_및_회원가입_완료_성공() {
+            // given
+            String email = "test@example.com";
+            String code = "123456";
+            String tempUserId = "temp-user-id";
+            String tempUserKey = "tempUser:" + tempUserId;
+            String password = "encodedPassword";
+            String nickname = "nickname1";
+            LocalDate birth = LocalDate.of(2000, 12, 12);
+            Gender gender = Gender.MALE;
+            UserRole userRole = UserRole.USER;
+
+            given(emailService.verifyCode(email, code)).willReturn(true);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get("email2tempId:" + email)).willReturn(tempUserId);
+            given(redisTemplate.opsForHash()).willReturn(hashOperations);
+
+            Map<Object, Object> userDataMap = new HashMap<>();
+            userDataMap.put("email", email);
+            userDataMap.put("password", password);
+            userDataMap.put("nickname", nickname);
+            userDataMap.put("birth", birth.toString());
+            userDataMap.put("gender", gender.toString());
+            userDataMap.put("userRole", userRole.toString());
+            given(hashOperations.entries(tempUserKey)).willReturn(userDataMap);
+
+            // when
+            boolean result = authService.verifyCodeAndCompleteSignup(email, code);
+
+            // then
+            assertTrue(result);
+            verify(userRepository).save(any(User.class));
+            verify(redisTemplate, times(4)).delete(anyString());
         }
     }
 
@@ -135,6 +257,7 @@ class AuthServiceTest {
             User user = User.create(email, password, userRole, null, nickname, birth, gender);
             given(userRepository.findByEmail(any())).willReturn(Optional.of(user));
             given(passwordEncoder.matches(any(), any())).willReturn(true);
+            given(session.getId()).willReturn("session-id");
 
             // when
             User signinUser = authService.signin(session, response, email, password);
@@ -145,6 +268,14 @@ class AuthServiceTest {
             AuthUser capturedAuthUser = authUserCaptor.getValue();
             assertEquals(user.getId(), capturedAuthUser.getId());
             assertEquals(user.getUserRole(), capturedAuthUser.getUserRole());
+
+            ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+            verify(response).addCookie(cookieCaptor.capture());
+            Cookie cookie = cookieCaptor.getValue();
+            assertEquals("JSESSIONID", cookie.getName());
+            assertEquals("session-id", cookie.getValue());
+            assertEquals(24 * 60 * 60, cookie.getMaxAge());
+            assertTrue(cookie.isHttpOnly());
 
             verify(userRepository, times(1)).findByEmail(any());
             verify(passwordEncoder, times(1)).matches(any(), any());
@@ -160,12 +291,18 @@ class AuthServiceTest {
     class 로그아웃_테스트 {
         @Test
         void 로그아웃_성공() {
-            // given
-
             // when
             authService.signout(session, response);
+
             // then
-            verify(session, times(1)).invalidate();
+            ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+            verify(response).addCookie(cookieCaptor.capture());
+            Cookie cookie = cookieCaptor.getValue();
+            assertEquals("JSESSIONID", cookie.getName());
+            assertThat(cookie.getValue()).isNull();
+            assertEquals(0, cookie.getMaxAge());
+
+            verify(session).invalidate();
         }
     }
 }

--- a/src/test/java/com/example/picket/domain/email/service/EmailServiceTest.java
+++ b/src/test/java/com/example/picket/domain/email/service/EmailServiceTest.java
@@ -1,0 +1,244 @@
+package com.example.picket.domain.email.service;
+
+import com.example.picket.common.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.SendEmailRequest;
+import software.amazon.awssdk.services.ses.model.SesException;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock
+    private SesClient sesClient;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private EmailService emailService;
+
+    @BeforeEach
+    void setUp() {
+        emailService = new EmailService(sesClient, templateEngine, redisTemplate);
+        ReflectionTestUtils.setField(emailService, "sender", "test@example.com");
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void 인증_코드_생성_시_생성된_코드는_6자리_숫자() throws Exception {
+        // given
+        Method method = EmailService.class.getDeclaredMethod("generateVerificationCode");
+        method.setAccessible(true);
+
+        // when
+        String code = (String) method.invoke(emailService);
+
+        // then
+        assertThat(code).hasSize(6);
+        assertThat(code).matches("\\d{6}");
+    }
+
+    @Test
+    void 인증_코드_저장_성공() throws Exception {
+        // given
+        String email = "user@example.com";
+        String code = "123456";
+        Method method = EmailService.class.getDeclaredMethod("saveVerificationCode", String.class, String.class);
+        method.setAccessible(true);
+
+        // when
+        method.invoke(emailService, email, code);
+
+        // then
+        verify(valueOperations).set(
+                eq("verification:user@example.com"),
+                eq("123456"),
+                eq(5L),
+                eq(TimeUnit.MINUTES)
+        );
+    }
+
+    @Test
+    void 이메일_인증_완료_표시_성공() throws Exception {
+        // given
+        String email = "user@example.com";
+        Method method = EmailService.class.getDeclaredMethod("markEmailAsVerified", String.class);
+        method.setAccessible(true);
+
+        // when
+        method.invoke(emailService, email);
+
+        // then
+        verify(valueOperations).set(
+                eq("verified:user@example.com"),
+                eq("true"),
+                eq(30L),
+                eq(TimeUnit.MINUTES)
+        );
+    }
+
+    @Test
+    void 이메일_발송_시_템플릿_처리_성공() throws Exception {
+        // given
+        String code = "123456";
+        String processedContent = "<html>코드: 123456</html>";
+        Method method = EmailService.class.getDeclaredMethod("createEmailContent", String.class);
+        method.setAccessible(true);
+
+        given(templateEngine.process(eq("verification-email"), any(Context.class))).willReturn(processedContent);
+
+        // when
+        String content = (String) method.invoke(emailService, code);
+
+        // then
+        verify(templateEngine).process(eq("verification-email"), any(Context.class));
+        assertThat(content).isEqualTo(processedContent);
+    }
+
+    @Nested
+    class 이메일_발송_테스트 {
+        @Test
+        void 이메일_발송_성공() throws Exception {
+            // given
+            String recipientEmail = "user@example.com";
+            String subject = "테스트 제목";
+            String content = "<html>테스트 내용</html>";
+            Method method = EmailService.class.getDeclaredMethod("sendEmail", String.class, String.class, String.class);
+            method.setAccessible(true);
+
+            // when
+            method.invoke(emailService, recipientEmail, subject, content);
+
+            // then
+            ArgumentCaptor<SendEmailRequest> requestCaptor = ArgumentCaptor.forClass(SendEmailRequest.class);
+            verify(sesClient).sendEmail(requestCaptor.capture());
+
+            SendEmailRequest capturedRequest = requestCaptor.getValue();
+            assertThat(capturedRequest.source()).isEqualTo("test@example.com");
+            assertThat(capturedRequest.destination().toAddresses()).contains("user@example.com");
+            assertThat(capturedRequest.message().subject().data()).isEqualTo("테스트 제목");
+            assertThat(capturedRequest.message().body().html().data()).isEqualTo("<html>테스트 내용</html>");
+        }
+
+        @Test
+        void SES_예외_발생시_CustomException_반환() throws Exception {
+            // given
+            String recipientEmail = "user@example.com";
+            String subject = "테스트 제목";
+            String content = "<html>테스트 내용</html>";
+            Method method = EmailService.class.getDeclaredMethod("sendEmail", String.class, String.class, String.class);
+            method.setAccessible(true);
+
+            doThrow(SesException.class).when(sesClient).sendEmail(any(SendEmailRequest.class));
+
+            // when & then
+            assertThatThrownBy(() -> method.invoke(emailService, recipientEmail, subject, content))
+                    .hasCauseInstanceOf(CustomException.class);
+        }
+
+        @Test
+        void 인증_메일_발송_성공() {
+            // given
+            String email = "user@example.com";
+            String processedContent = "<html>코드: 123456</html>";
+
+            given(templateEngine.process(eq("verification-email"), any(Context.class))).willReturn(processedContent);
+
+            // when
+            String resultCode = emailService.sendVerificationEmail(email);
+
+            // then
+            assertThat(resultCode).hasSize(6);
+            assertThat(resultCode).matches("\\d{6}");
+
+            verify(valueOperations).set(
+                    argThat(key -> key.startsWith("verification:")),
+                    eq(resultCode),
+                    eq(5L),
+                    eq(TimeUnit.MINUTES)
+            );
+
+            verify(sesClient).sendEmail(any(SendEmailRequest.class));
+        }
+    }
+
+    @Nested
+    class 인증코드_테스트 {
+        @Test
+        void 인증_코드_검증_성공() {
+            // given
+            String email = "user@example.com";
+            String code = "123456";
+            given(valueOperations.get("verification:user@example.com")).willReturn(code);
+
+            // when
+            boolean result = emailService.verifyCode(email, code);
+
+            // then
+            assertThat(result).isTrue();
+            verify(valueOperations).set(
+                    eq("verified:user@example.com"),
+                    eq("true"),
+                    eq(30L),
+                    eq(TimeUnit.MINUTES)
+            );
+        }
+
+        @Test
+        void 저장된_코드_없음() {
+            // given
+            String email = "user@example.com";
+            String code = "123456";
+            given(valueOperations.get("verification:user@example.com")).willReturn(null);
+
+            // when
+            boolean result = emailService.verifyCode(email, code);
+
+            // then
+            assertThat(result).isFalse();
+            verify(valueOperations, never()).set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+        }
+
+        @Test
+        void 코드_불일치() {
+            // given
+            String email = "user@example.com";
+            String code = "123456";
+            String storedCode = "654321";
+            given(valueOperations.get("verification:user@example.com")).willReturn(storedCode);
+
+            // when
+            boolean result = emailService.verifyCode(email, code);
+
+            // then
+            assertThat(result).isFalse();
+            verify(valueOperations, never()).set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+        }
+    }
+}


### PR DESCRIPTION
## 📌 반영 브랜치
feat/SES -> dev

## ✅ 작업 내용


- 회원가입 시 정보 입력 후 이메일로 인증 코드가 발송 되고, 그 인증 코드를 입력해야 회원가입이 완료됨.
- 인증 코드 이메일 재전송은 사용자가 재전송 버튼을 눌렀을 때 실행됨.


## 🎯 단독 테스트 결과

단위 테스트 TestCode 통해 확인
PostMan 통해 통합 테스트 확인 완료
단, AWS 샌드박스 계정이라  AWS SES에 자격 증명이 된 이메일로만 메일을 보낼 수 있음.

## 🚨 연관 이슈
#123 