### PR TITLE
Feat/session redis : 세션 저장소를 Redis로 전환

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -10,7 +10,29 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: 🧪 Run Gradle Build & Tests
-
+    services:
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_DATABASE: jdbc:mysql://localhost:3306/picket-mysql
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent "
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
     steps:
       # 1. 최신 코드 체크아웃
       - name: 📦 Checkout Repository

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -14,13 +14,14 @@ jobs:
       mysql:
         image: mysql:latest
         env:
-          MYSQL_DATABASE: jdbc:mysql://localhost:3306/picket-mysql
+          MYSQL_ROOT_PASSWORD: 1111
+          MYSQL_DATABASE: picket-mysql
           MYSQL_USER: test
           MYSQL_PASSWORD: test
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping --silent "
+          --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-cache'
 
+    //spring session
+    implementation 'org.springframework.session:spring-session-data-redis'
+
     // AWS
     implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
+    testRuntimeOnly 'com.h2database:h2'
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -89,9 +89,9 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-bootRun {
+/*bootRun {
     systemProperty 'spring.profiles.active', 'local'
-}
+}*/
 
 bootJar {
     archiveBaseName.set('picket')

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly 'com.h2database:h2'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -89,9 +89,6 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-/*bootRun {
-    systemProperty 'spring.profiles.active', 'local'
-}*/
 
 bootJar {
     archiveBaseName.set('picket')

--- a/src/main/java/com/example/picket/common/dto/AuthUser.java
+++ b/src/main/java/com/example/picket/common/dto/AuthUser.java
@@ -1,6 +1,8 @@
 package com.example.picket.common.dto;
 
 import com.example.picket.common.enums.UserRole;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,13 +11,12 @@ import java.io.Serializable;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AuthUser implements Serializable {
-    private static final long serialVersionUID = 1L;
-
+public class AuthUser{
     private Long id;
     private UserRole userRole;
 
-    private AuthUser(Long id, UserRole userRole) {
+    @JsonCreator
+    private AuthUser(@JsonProperty("id") Long id, @JsonProperty("userRole")UserRole userRole) {
         this.id = id;
         this.userRole = userRole;
     }

--- a/src/main/java/com/example/picket/common/dto/AuthUser.java
+++ b/src/main/java/com/example/picket/common/dto/AuthUser.java
@@ -5,9 +5,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AuthUser {
+public class AuthUser implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private Long id;
     private UserRole userRole;

--- a/src/main/java/com/example/picket/common/dto/AuthUser.java
+++ b/src/main/java/com/example/picket/common/dto/AuthUser.java
@@ -7,8 +7,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.io.Serializable;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthUser{

--- a/src/main/java/com/example/picket/config/RedisSessionConfig.java
+++ b/src/main/java/com/example/picket/config/RedisSessionConfig.java
@@ -1,0 +1,15 @@
+package com.example.picket.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisSessionConfig {
+    @Bean
+    public GenericJackson2JsonRedisSerializer springSessionDefaultRedisSerializer() {
+        return new GenericJackson2JsonRedisSerializer();
+    }
+}

--- a/src/main/java/com/example/picket/domain/auth/controller/OAuthController.java
+++ b/src/main/java/com/example/picket/domain/auth/controller/OAuthController.java
@@ -9,6 +9,8 @@ import com.example.picket.domain.auth.dto.response.SessionResponse;
 import com.example.picket.domain.auth.service.OAuthService;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,11 +21,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2")
+@Tag(name = "Auth API", description = "인증 및 OAuth 관련 API")
 public class OAuthController {
 
     private final OAuthService oAuthService;
     private final UserQueryService userQueryService;
 
+    @Operation(summary = "세션 조회", description = "현재 로그인된 세션 정보를 조회합니다.")
     @GetMapping("/auth/session")
     public ResponseEntity<SessionResponse> getSession(@Auth AuthUser auth) {
         if (auth == null) {
@@ -34,6 +38,12 @@ public class OAuthController {
         return ResponseEntity.ok(SessionResponse.of(user.getNickname(), user.getEmail(), user.getUserRole()));
     }
 
+    @Operation(
+            summary = "구글 OAuth 로그인 (User)",
+            description = "Google OAuth를 통해 일반 사용자(User)로 로그인합니다." +
+                    "\n\n※ Swagger에서는 OAuth 인가 코드 발급 과정을 거칠 수 없어 테스트할 수 없습니다." +
+                    " 브라우저를 통해 직접 로그인 플로우를 타야 정상적으로 code를 받을 수 있습니다."
+    )
     @GetMapping("/auth/callback/user")
     public ResponseEntity<OAuthSigninResponse> googleUserSignin(@RequestParam("code") String code, HttpSession session) {
 
@@ -41,6 +51,12 @@ public class OAuthController {
         return ResponseEntity.ok(OAuthSigninResponse.of(user.getNickname(), user.getNickname() == null));
     }
 
+    @Operation(
+            summary = "구글 OAuth 로그인 (Admin)",
+            description = "Google OAuth를 통해 일반 관리자(Admin)로 로그인합니다." +
+                    "\n\n※ Swagger에서는 OAuth 인가 코드 발급 과정을 거칠 수 없어 테스트할 수 없습니다." +
+                    " 브라우저를 통해 직접 로그인 플로우를 타야 정상적으로 code를 받을 수 있습니다."
+    )
     @GetMapping("/auth/callback/admin")
     public ResponseEntity<OAuthSigninResponse> googleAdminSignin(@RequestParam("code") String code, HttpSession session) {
 
@@ -48,6 +64,12 @@ public class OAuthController {
         return ResponseEntity.ok(OAuthSigninResponse.of(user.getNickname(), user.getNickname() == null));
     }
 
+    @Operation(
+            summary = "구글 OAuth 로그인 (Director)",
+            description = "Google OAuth를 통해 감독자(Director)로 로그인합니다." +
+                    "\n\n※ Swagger에서는 OAuth 인가 코드 발급 과정을 거칠 수 없어 테스트할 수 없습니다." +
+                    " 브라우저를 통해 직접 로그인 플로우를 타야 정상적으로 code를 받을 수 있습니다."
+    )
     @GetMapping("/auth/callback/director")
     public ResponseEntity<OAuthSigninResponse> googleDirectorSignin(@RequestParam("code") String code, HttpSession session) {
 
@@ -55,6 +77,7 @@ public class OAuthController {
         return ResponseEntity.ok(OAuthSigninResponse.of(user.getNickname(), user.getNickname() == null));
     }
 
+    @Operation(summary = "구글 신규회원 가입", description = "Google OAuth 인증 후, 신규 사용자의 닉네임, 생년월일, 성별을 등록합니다.")
     @PostMapping("/auth/signup")
     public ResponseEntity<Void> googleSignup(@Auth AuthUser authUser, @Valid @RequestBody OAuthSignupRequest request) {
         oAuthService.signup(authUser.getId(), request.getNickname(), request.getBirth(), request.getGender());

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,3 +38,22 @@ oauth:
       admin: http://localhost:8080/api/v2/auth/callback/admin
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
+
+cloud:
+  aws:
+    credentials:
+      access-key: dummy-access-key
+      secret-key: dummy-secret-key
+    s3:
+      bucket: dummy-s3-bucket
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+aws:
+  region: ap-northeast-2
+  ses:
+    access-key: dummy-ses-access-key
+    secret-key: dummy-ses-secret-key
+    send-mail-from: dummy@example.com

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,11 +22,17 @@ spring:
       host: localhost
       port: 6379
 
+  session:
+    store-type: redis
+    redis:
+      namespace: spring:session
+    timeout: 60m
+
 oauth:
   google:
-    client-id: ${CLIENT_ID}
-    client-secret: ${CLIENT_SECRET_KEY}
-    redirect-uris:
+    client-id: dummy-client-id
+    client-secret: dummy-client-secret
+    redirect-uris :
       director: http://localhost:8080/api/v2/auth/callback/director
       user: http://localhost:8080/api/v2/auth/callback/user
       admin: http://localhost:8080/api/v2/auth/callback/admin

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,14 +28,20 @@ spring:
           max-idle: 8
           min-idle: 0
 
+  session:
+    store-type: redis
+    redis:
+      namespace: spring:session
+    timeout: 60m
+
 oauth:
   google:
     client-id: ${CLIENT_ID}
     client-secret: ${CLIENT_SECRET_KEY}
     redirect-uris:
-      director: https://www.thepickets.com/api/v2/auth/callback/director
-      user: https://www.thepickets.com/api/v2/auth/callback/user
-      admin: https://www.thepickets.com/api/v2/auth/callback/admin
+      director: https://thepickets.com/api/v2/auth/callback/director
+      user: https://thepickets.com/api/v2/auth/callback/user
+      admin: https://thepickets.com/api/v2/auth/callback/admin
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
       host: localhost
       port: 6379
 
+  session:
+    store-type: redis
+    redis:
+      namespace: spring:session
+    timeout: 60m
+
 oauth:
   google:
     client-id: ${CLIENT_ID}

--- a/src/test/java/com/example/picket/integration/session/RedisSessionTest.java
+++ b/src/test/java/com/example/picket/integration/session/RedisSessionTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +31,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("local")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Transactional
 public class RedisSessionTest {

--- a/src/test/java/com/example/picket/integration/session/RedisSessionTest.java
+++ b/src/test/java/com/example/picket/integration/session/RedisSessionTest.java
@@ -1,0 +1,124 @@
+package com.example.picket.integration.session;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RedisSessionTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    private Cookie[] cookies;
+
+    @BeforeEach
+    void 회원가입_및_이메일_로그인_요청_및_세션_저장() throws Exception {
+        //회원가입
+        mockMvc.perform(post("/api/v1/auth/signup/user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"test@example.com\"" +
+                                ",\"password\":\"Test123!!\"" +
+                                ", \"nickname\": \"테스터\"" +
+                                ", \"birth\": \"2000-12-12\"" +
+                                ", \"gender\": \"MALE\"}")
+                )
+                .andExpect(status().isOk());
+
+        // 로그인
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/signin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"test@example.com\",\"password\":\"Test123!!\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        cookies = result.getResponse().getCookies();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RedisConnection connection = redisConnectionFactory.getConnection();
+        connection.flushAll(); // 테스트 후 Redis 전체 비우기
+    }
+
+    @Test
+    void Redis에_세션이_저장() {
+        RedisConnection connection = redisConnectionFactory.getConnection();
+        Set<byte[]> keys = connection.keys("spring:session:sessions:*".getBytes());
+        assertThat(keys).isNotEmpty();
+    }
+
+    @Test
+    void TTL이_요청_시마다_자동_갱신_체크() throws Exception {
+        RedisConnection connection = redisConnectionFactory.getConnection();
+        String sessionId = extractSessionIdFromCookie(cookies);
+
+        // TTL이 줄어들도록 대기
+        Thread.sleep(5000);
+        Long ttlBefore = connection.ttl(("spring:session:sessions:" + sessionId).getBytes());
+        System.out.println("TTL Before = " + ttlBefore);
+
+        mockMvc.perform(get("/api/v1/users").cookie(cookies))
+                .andExpect(status().isOk());
+
+        Long ttlAfter = connection.ttl(("spring:session:sessions:" + sessionId).getBytes());
+        System.out.println("TTL After  = " + ttlAfter);
+
+        assertThat(ttlAfter).isGreaterThan(ttlBefore);
+    }
+
+    @Test
+    void 세션_만료_시_재로그인() throws Exception {
+        String sessionId = extractSessionIdFromCookie(cookies);
+        RedisConnection connection = redisConnectionFactory.getConnection();
+        connection.del(("spring:session:sessions:" + sessionId).getBytes());
+
+        mockMvc.perform(get("/api/v1/auth/users").cookie(cookies))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 로그아웃_호출시_Redis_세션_삭제() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/signout").cookie(cookies))
+                .andExpect(status().isOk());
+
+        String sessionId = extractSessionIdFromCookie(cookies);
+        RedisConnection connection = redisConnectionFactory.getConnection();
+        Boolean exists = connection.exists(("spring:session:sessions:" + sessionId).getBytes());
+        assertThat(exists).isFalse();
+    }
+
+    private String extractSessionIdFromCookie(Cookie[] cookies) {
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals("JSESSIONID"))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,59 @@
+spring:
+  application:
+    name: Picket
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/picket-mysql
+    username: test
+    password: test
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  session:
+    store-type: redis
+    redis:
+      namespace: spring:session
+    timeout: 60m
+
+oauth:
+  google:
+    client-id: dummy-client-id
+    client-secret: dummy-client-secret
+    redirect-uris:
+      director: http://localhost:8080/api/v2/auth/callback/director
+      user: http://localhost:8080/api/v2/auth/callback/user
+      admin: http://localhost:8080/api/v2/auth/callback/admin
+    token-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
+
+cloud:
+  aws:
+    credentials:
+      access-key: dummy-access-key
+      secret-key: dummy-secret-key
+    s3:
+      bucket: dummy-s3-bucket
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+aws:
+  region: ap-northeast-2
+  ses:
+    access-key: dummy-ses-access-key
+    secret-key: dummy-ses-secret-key
+    send-mail-from: dummy@example.com


### PR DESCRIPTION
### 📌 반영 브랜치
feat/session-redis -> dev

### ✅ 작업 내용
- Redis 세션 저장소를 전환하여 서버 재시작 및 다중 서버 환경에서도 세션 일관성 유지
- yml에 Redis 세션 저장소 및 TTL 설정 추가
- Redis 세션 저장소 핵심 동작을 검증하는 통합 테스트 코드 작성

### 🎯 단독 테스트 결과
- 로그인 시 세션이 Redis에 정상 저장되는지 확인
- 요청 시마다 세션 TTL이 자동 갱신되는지 확인
- 세션 만료 후 재로그인 처리 흐름 정상 동작 확인
- 로그아웃 시 Redis에서 세션 키 삭제 확인
- application-local.yml 적용 및 Redis 서버 실행 상태에서 통합 테스트 정상 통과

### 🚨 연관 이슈
closes #120 
closes #121 