### PR TITLE
Payment : 토스페이먼츠 결제 연동

### DIFF
--- a/src/main/java/com/example/picket/common/enums/OrderStatus.java
+++ b/src/main/java/com/example/picket/common/enums/OrderStatus.java
@@ -8,7 +8,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 public enum OrderStatus {
     ORDER_PENDING("결제 대기"),
-    ORDER_COMPLETE("주문 완료");
+    ORDER_COMPLETE("주문 완료"),
+    ORDER_CANCELED("주문 취소");
 
     private final String description;
 

--- a/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
@@ -35,7 +35,7 @@ public class BookingController {
             @Auth AuthUser authUser,
             @RequestBody BookingRequest dto
     ) throws InterruptedException {
-        Order order = bookingFacade.booking(showId, showDateId, authUser.getId(), dto.getSeatIds());
+        Order order = bookingFacade.booking(showId, showDateId, authUser.getId(), dto.getSeatIds(), dto.getPaymentKey(), dto.getOrderId(), dto.getAmount());
         OrderResponse orderResponse = OrderResponse.of(order);
         return ResponseEntity.ok(orderResponse);
     }

--- a/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/example/picket/domain/booking/controller/BookingController.java
@@ -41,14 +41,15 @@ public class BookingController {
     }
 
     @Operation(summary = "예매취소", description = "예매된 티켓을 취소할 수 있습니다.")
-    @DeleteMapping("show/{showId}/show-date/{showDateId}/booking")
+    @DeleteMapping("show/{showId}/show-date/{showDateId}/booking/{paymentId}")
     public ResponseEntity<CancelBookingResponse> cancelBooking(
             @PathVariable Long showId,
             @PathVariable Long showDateId,
+            @PathVariable Long paymentId,
             @Auth AuthUser authUser,
             @RequestBody CancelBookingRequest dto
     ) throws InterruptedException {
-        List<Ticket> canceledTickets = bookingFacade.cancelBooking(showId, showDateId, authUser.getId(), dto.getTicketIds());
+        List<Ticket> canceledTickets = bookingFacade.cancelBooking(showId, showDateId, authUser.getId(), paymentId, dto.getTicketIds(), dto.getCancelReason());
         List<GetTicketResponse> getTicketResponses = canceledTickets.stream().map(GetTicketResponse::of).toList();
         CancelBookingResponse cancelBookingResponse = CancelBookingResponse.of(getTicketResponses);
         return ResponseEntity.ok(cancelBookingResponse);

--- a/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
@@ -25,5 +25,5 @@ public class BookingRequest {
 
     @Schema(description = "결제할 amount")
     @NotNull(message = "amount는 필수 입력값입니다.")
-    private Number amount;
+    private BigDecimal amount;
 }

--- a/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,5 +13,17 @@ public class BookingRequest {
 
     @Schema(description = "예매할 좌석 ID", example = "[1]")
     @NotNull(message = "좌석 ID는 필수 입력값입니다.")
-    private final List<Long> seatIds = new ArrayList<>();
+    private List<Long> seatIds = new ArrayList<>();
+
+    @Schema(description = "예매할 좌석 ID")
+    @NotNull(message = "paymentKey는 필수 입력값입니다.")
+    private String paymentKey;
+
+    @Schema(description = "예매할 좌석 ID")
+    @NotNull(message = "orderId는 필수 입력값입니다.")
+    private String orderId;
+
+    @Schema(description = "예매할 좌석 ID", example = "300")
+    @NotNull(message = "amount는 필수 입력값입니다.")
+    private Number amount;
 }

--- a/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/request/BookingRequest.java
@@ -15,15 +15,15 @@ public class BookingRequest {
     @NotNull(message = "좌석 ID는 필수 입력값입니다.")
     private List<Long> seatIds = new ArrayList<>();
 
-    @Schema(description = "예매할 좌석 ID")
+    @Schema(description = "결제할 paymentKey")
     @NotNull(message = "paymentKey는 필수 입력값입니다.")
     private String paymentKey;
 
-    @Schema(description = "예매할 좌석 ID")
+    @Schema(description = "결제할 orderId")
     @NotNull(message = "orderId는 필수 입력값입니다.")
     private String orderId;
 
-    @Schema(description = "예매할 좌석 ID", example = "300")
+    @Schema(description = "결제할 amount")
     @NotNull(message = "amount는 필수 입력값입니다.")
     private Number amount;
 }

--- a/src/main/java/com/example/picket/domain/booking/dto/request/CancelBookingRequest.java
+++ b/src/main/java/com/example/picket/domain/booking/dto/request/CancelBookingRequest.java
@@ -13,4 +13,8 @@ public class CancelBookingRequest {
     @Schema(description = "취소할 티켓 ID", example = "[1]")
     @NotNull(message = "티켓 ID는 필수 입력값입니다.")
     private final List<Long> ticketIds = new ArrayList<>();
+
+    @Schema(description = "취소 이유", example = "단순 변심")
+    @NotNull(message = "취소 이유는 필수 입력값입니다.")
+    private String cancelReason;
 }

--- a/src/main/java/com/example/picket/domain/booking/service/BookingFacade.java
+++ b/src/main/java/com/example/picket/domain/booking/service/BookingFacade.java
@@ -33,13 +33,13 @@ public class BookingFacade {
         }
     }
 
-    public List<Ticket> cancelBooking(Long showId, Long showDateId, Long userId, List<Long> ticketIds) throws InterruptedException {
+    public List<Ticket> cancelBooking(Long showId, Long showDateId, Long userId, Long paymentId, List<Long> ticketIds, String cancelReason) throws InterruptedException {
         String lockKey = KEY_PREFIX + showDateId;
         RLock lock = redissonClient.getFairLock(lockKey);
 
         if (lock.tryLock(10, TimeUnit.SECONDS)) {
             try {
-                return bookingService.cancelBooking(showId, showDateId, userId, ticketIds);
+                return bookingService.cancelBooking(showId, showDateId, userId, paymentId, ticketIds, cancelReason);
             } finally {
                 lock.unlock();
             }

--- a/src/main/java/com/example/picket/domain/booking/service/BookingFacade.java
+++ b/src/main/java/com/example/picket/domain/booking/service/BookingFacade.java
@@ -7,6 +7,7 @@ import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -17,13 +18,13 @@ public class BookingFacade {
     private final RedissonClient redissonClient;
     private final String KEY_PREFIX = "BOOKING-LOCK:SHOW-DATE:";
 
-    public Order booking(Long showId, Long showDateId, Long userId, List<Long> seatIds) throws InterruptedException {
+    public Order booking(Long showId, Long showDateId, Long userId, List<Long> seatIds, String paymentKey, String orderId, Number amount) throws InterruptedException {
         String lockKey = KEY_PREFIX + showDateId;
         RLock lock = redissonClient.getFairLock(lockKey);
 
         if (lock.tryLock(10, TimeUnit.SECONDS)) {
             try {
-                return bookingService.booking(showId, showDateId, userId, seatIds);
+                return bookingService.booking(showId, showDateId, userId, seatIds, paymentKey, orderId, amount);
             } finally {
                 lock.unlock();
             }

--- a/src/main/java/com/example/picket/domain/booking/service/BookingFacade.java
+++ b/src/main/java/com/example/picket/domain/booking/service/BookingFacade.java
@@ -18,7 +18,7 @@ public class BookingFacade {
     private final RedissonClient redissonClient;
     private final String KEY_PREFIX = "BOOKING-LOCK:SHOW-DATE:";
 
-    public Order booking(Long showId, Long showDateId, Long userId, List<Long> seatIds, String paymentKey, String orderId, Number amount) throws InterruptedException {
+    public Order booking(Long showId, Long showDateId, Long userId, List<Long> seatIds, String paymentKey, String orderId, BigDecimal amount) throws InterruptedException {
         String lockKey = KEY_PREFIX + showDateId;
         RLock lock = redissonClient.getFairLock(lockKey);
 

--- a/src/main/java/com/example/picket/domain/booking/service/BookingService.java
+++ b/src/main/java/com/example/picket/domain/booking/service/BookingService.java
@@ -129,7 +129,7 @@ public class BookingService {
 
             Order order = orderCommandService.createOrder(foundUser, tickets);
 
-            paymentCommandService.create(tossPaymentKey, tossOrderId, tossOrderName, tossStatus, tossTotalAmount, order);
+            paymentCommandService.createPayment(tossPaymentKey, tossOrderId, tossOrderName, tossStatus, tossTotalAmount, order);
 
             showDateCommandService.countUpdateOnBooking(showDateId, seatIds.size());
 
@@ -204,7 +204,7 @@ public class BookingService {
         }
 
         // 예매 취소 로직
-        paymentCommandService.create(tossPaymentKey, tossOrderId, tossOrderName, tossStatus, cancelAmount, foundOrder);
+        paymentCommandService.createPayment(tossPaymentKey, tossOrderId, tossOrderName, tossStatus, cancelAmount, foundOrder);
 
         ShowDate foundShowDate = showDateQueryService.getShowDate(showDateId);
         checkCancelBookingTime(foundShowDate);

--- a/src/main/java/com/example/picket/domain/booking/service/BookingService.java
+++ b/src/main/java/com/example/picket/domain/booking/service/BookingService.java
@@ -4,6 +4,8 @@ import com.example.picket.common.enums.OrderStatus;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.order.entity.Order;
 import com.example.picket.domain.order.service.OrderCommandService;
+import com.example.picket.domain.payment.entity.Payment;
+import com.example.picket.domain.payment.service.PaymentService;
 import com.example.picket.domain.seat.service.SeatQueryService;
 import com.example.picket.domain.seat_holding.service.SeatHoldingService;
 import com.example.picket.domain.show.entity.Show;
@@ -19,12 +21,21 @@ import com.example.picket.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -43,28 +54,93 @@ public class BookingService {
     private final OrderCommandService orderCommandService;
     private final TicketCommandService ticketCommandService;
     private final ShowDateCommandService showDateCommandService;
+    private final PaymentService paymentService;
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private static final String KEY_PREFIX = "PAYMENT-INFO:USER:";
+    private static final String SECRET_KEY = "test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6";
+    private static final String TOSS_API_URL = "https://api.tosspayments.com/v1/payments/confirm";
 
     @Transactional
-    public Order booking(Long showId, Long showDateId, Long userId, List<Long> seatIds) throws InterruptedException {
+    public Order booking(Long showId, Long showDateId, Long userId, List<Long> seatIds, String paymentKey, String orderId, Number amount) throws InterruptedException {
 
-        Show foundShow = showQueryService.getShow(showId); // select
-        checkBookingTime(foundShow);
+        String key = KEY_PREFIX + userId;
+        //orderId, amount 비교
+        String orderIdFromRedis = (String) stringRedisTemplate.opsForHash().get(key, "orderId");
+        String amountFromRedis = (String) stringRedisTemplate.opsForHash().get(key, "amount");
 
-        User foundUser = userQueryService.getUser(userId); // select
+        System.out.println(orderIdFromRedis);
+        System.out.println(amountFromRedis);
+        System.out.println(amount.toString());
 
-        seatHoldingService.seatHoldingCheck(userId, seatIds);
+        // orderId 검증
+        if (orderIdFromRedis == null || !orderIdFromRedis.equals(orderId)) {
+            throw new CustomException(BAD_REQUEST, "결제 인증 정보(orderId)가 변경되었습니다.");
+        }
 
-        ticketQueryService.checkTicketLimit(foundUser, foundShow); // select
 
-        List<Ticket> tickets = ticketCommandService.createTicket(foundUser, foundShow, seatIds); // insert
+        if (amountFromRedis == null || !amountFromRedis.equals(amount.toString())) {
+            throw new CustomException(BAD_REQUEST, "결제 인증 정보(amount)가 변경되었습니다.");
+        }
 
-        Order order = orderCommandService.createOrder(foundUser, tickets); // insert
+        // 승인 API 호출
+        String encodedSecretKey = "Basic " + Base64.getEncoder().encodeToString((SECRET_KEY + ":").getBytes());
 
-        showDateCommandService.countUpdate(showDateId, seatIds.size()); // update
+        // 요청 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", encodedSecretKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
 
-        seatHoldingService.seatHoldingUnLock(seatIds);
+        // 요청 바디 설정
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("orderId", orderId);
+        requestBody.put("amount", amount);
+        requestBody.put("paymentKey", paymentKey);
 
-        return order;
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        // API 호출
+        ResponseEntity<Map> response = restTemplate.exchange(
+                TOSS_API_URL,
+                HttpMethod.POST,
+                entity,
+                Map.class
+        );
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            // 결제 성공 비즈니스 로직 구현
+            Map<String, Object> responseBody = response.getBody();
+            String tossPaymentKey = (String) responseBody.get("paymentKey");
+            String tossOrderId = (String) responseBody.get("orderId");
+            String tossOrderName = (String) responseBody.get("orderName");
+            String tossStatus = (String) responseBody.get("status");
+            Number tossTotalAmount = (Number) responseBody.get("totalAmount");
+
+            Show foundShow = showQueryService.getShow(showId); // select
+            checkBookingTime(foundShow);
+
+            User foundUser = userQueryService.getUser(userId); // select
+
+            seatHoldingService.seatHoldingCheck(userId, seatIds);
+
+            ticketQueryService.checkTicketLimit(foundUser, foundShow); // select
+
+            List<Ticket> tickets = ticketCommandService.createTicket(foundUser, foundShow, seatIds); // insert
+
+            Order order = orderCommandService.createOrder(foundUser, tickets); // insert
+
+            paymentService.create(tossPaymentKey, tossOrderId, tossOrderName, tossStatus, tossTotalAmount, order);
+
+            showDateCommandService.countUpdate(showDateId, seatIds.size()); // update
+
+            seatHoldingService.seatHoldingUnLock(seatIds);
+
+            return order;
+        } else {
+
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "결제 승인에 실패하였습니다.");
+        }
     }
 
     @Transactional

--- a/src/main/java/com/example/picket/domain/order/entity/Order.java
+++ b/src/main/java/com/example/picket/domain/order/entity/Order.java
@@ -41,6 +41,10 @@ public class Order extends BaseEntity {
         this.orderStatus = status;
     }
 
+    public void updateTotalPrice(BigDecimal totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+
     private Order(User user, BigDecimal totalPrice, OrderStatus orderStatus, List<Ticket> ticket) {
         this.user = user;
         this.totalPrice = totalPrice;

--- a/src/main/java/com/example/picket/domain/order/entity/Order.java
+++ b/src/main/java/com/example/picket/domain/order/entity/Order.java
@@ -30,6 +30,7 @@ public class Order extends BaseEntity {
     @Column(nullable = false)
     private BigDecimal totalPrice;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private OrderStatus orderStatus;
 

--- a/src/main/java/com/example/picket/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/picket/domain/payment/controller/PaymentController.java
@@ -3,7 +3,7 @@ package com.example.picket.domain.payment.controller;
 import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.domain.payment.dto.request.TemporarySaveRequest;
-import com.example.picket.domain.payment.service.PaymentService;
+import com.example.picket.domain.payment.service.PaymentCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -19,14 +19,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Tag(name = "결제 정보 임시저장 API", description = "결제 정보 임시 저장 API입니다.")
 public class PaymentController {
 
-    private final PaymentService paymentService;
+    private final PaymentCommandService paymentCommandService;
 
     @PostMapping("/temporary-save")
     @Operation(summary = "결제 정보 임시 저장", description = "결제 승인 전 결제 정보를 임시 저장합니다.")
     public ResponseEntity<Void> temporarySavePaymentInfo(
             @Auth AuthUser authUser,
             @RequestBody TemporarySaveRequest dto) {
-        paymentService.temporarySavePaymentInfo(dto.getOrderId(), dto.getAmount(), authUser.getId());
+        paymentCommandService.temporarySavePaymentInfo(dto.getOrderId(), dto.getAmount(), authUser.getId());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/picket/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/picket/domain/payment/controller/PaymentController.java
@@ -1,0 +1,28 @@
+package com.example.picket.domain.payment.controller;
+
+import com.example.picket.common.annotation.Auth;
+import com.example.picket.common.dto.AuthUser;
+import com.example.picket.domain.payment.dto.request.TemporarySaveRequest;
+import com.example.picket.domain.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v2/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/temporary-save")
+    public ResponseEntity<Void> temporarySavePaymentInfo(
+            @Auth AuthUser authUser,
+            @RequestBody TemporarySaveRequest dto) {
+        paymentService.temporarySavePaymentInfo(dto.getOrderId(), dto.getAmount(), authUser.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/picket/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/picket/domain/payment/controller/PaymentController.java
@@ -4,6 +4,8 @@ import com.example.picket.common.annotation.Auth;
 import com.example.picket.common.dto.AuthUser;
 import com.example.picket.domain.payment.dto.request.TemporarySaveRequest;
 import com.example.picket.domain.payment.service.PaymentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,11 +16,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping("/api/v2/payments")
 @RequiredArgsConstructor
+@Tag(name = "결제 정보 임시저장 API", description = "결제 정보 임시 저장 API입니다.")
 public class PaymentController {
 
     private final PaymentService paymentService;
 
     @PostMapping("/temporary-save")
+    @Operation(summary = "결제 정보 임시 저장", description = "결제 승인 전 결제 정보를 임시 저장합니다.")
     public ResponseEntity<Void> temporarySavePaymentInfo(
             @Auth AuthUser authUser,
             @RequestBody TemporarySaveRequest dto) {

--- a/src/main/java/com/example/picket/domain/payment/dto/request/TemporarySaveRequest.java
+++ b/src/main/java/com/example/picket/domain/payment/dto/request/TemporarySaveRequest.java
@@ -1,0 +1,22 @@
+package com.example.picket.domain.payment.dto.request;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class TemporarySaveRequest {
+
+    private String orderId;
+
+    private BigDecimal amount;
+
+    public TemporarySaveRequest(String orderId, BigDecimal amount) {
+        this.orderId = orderId;
+        this.amount = amount;
+    }
+
+    public static TemporarySaveRequest from(String orderId, BigDecimal amount) {
+        return new TemporarySaveRequest(orderId, amount);
+    }
+}

--- a/src/main/java/com/example/picket/domain/payment/dto/request/TemporarySaveRequest.java
+++ b/src/main/java/com/example/picket/domain/payment/dto/request/TemporarySaveRequest.java
@@ -15,7 +15,7 @@ public class TemporarySaveRequest {
 
     @Schema(description = "amount", example = "300")
     @NotNull(message = "amount는 필수 입력값입니다.")
-    private Number amount;
+    private BigDecimal amount;
 
     public TemporarySaveRequest(String orderId, BigDecimal amount) {
         this.orderId = orderId;

--- a/src/main/java/com/example/picket/domain/payment/dto/request/TemporarySaveRequest.java
+++ b/src/main/java/com/example/picket/domain/payment/dto/request/TemporarySaveRequest.java
@@ -9,11 +9,11 @@ import java.math.BigDecimal;
 @Getter
 public class TemporarySaveRequest {
 
-    @Schema(description = "orderId")
+    @Schema(description = "임시 저장할 orderId")
     @NotNull(message = "orderId는 필수 입력값입니다.")
     private String orderId;
 
-    @Schema(description = "amount", example = "300")
+    @Schema(description = "임시 저장할 amount")
     @NotNull(message = "amount는 필수 입력값입니다.")
     private BigDecimal amount;
 

--- a/src/main/java/com/example/picket/domain/payment/dto/request/TemporarySaveRequest.java
+++ b/src/main/java/com/example/picket/domain/payment/dto/request/TemporarySaveRequest.java
@@ -1,5 +1,7 @@
 package com.example.picket.domain.payment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.math.BigDecimal;
@@ -7,9 +9,13 @@ import java.math.BigDecimal;
 @Getter
 public class TemporarySaveRequest {
 
+    @Schema(description = "orderId")
+    @NotNull(message = "orderId는 필수 입력값입니다.")
     private String orderId;
 
-    private BigDecimal amount;
+    @Schema(description = "amount", example = "300")
+    @NotNull(message = "amount는 필수 입력값입니다.")
+    private Number amount;
 
     public TemporarySaveRequest(String orderId, BigDecimal amount) {
         this.orderId = orderId;

--- a/src/main/java/com/example/picket/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/picket/domain/payment/entity/Payment.java
@@ -27,7 +27,7 @@ public class Payment {
     private String tossOrderName;
 
     @Column(nullable = false)
-    private BigDecimal tossAmount;
+    private Number tossAmount;
 
     @Column(nullable = false)
     private String tossStatus;
@@ -40,15 +40,16 @@ public class Payment {
         this.order = order;
     }
 
-    public Payment(String tossPaymentKey, String tossOrderId, String tossOrderName, BigDecimal tossAmount, String tossStatus) {
+    public Payment(String tossPaymentKey, String tossOrderId, String tossOrderName, Number tossAmount, String tossStatus, Order order) {
         this.tossPaymentKey = tossPaymentKey;
         this.tossOrderId = tossOrderId;
         this.tossOrderName = tossOrderName;
         this.tossAmount = tossAmount;
         this.tossStatus = tossStatus;
+        this.order = order;
     }
 
-    public static Payment create(String tossPaymentKey, String tossOrderId, String tossOrderName, BigDecimal tossAmount, String tossStatus) {
-        return new Payment(tossPaymentKey, tossOrderId, tossOrderName, tossAmount, tossStatus);
+    public static Payment create(String tossPaymentKey, String tossOrderId, String tossOrderName, Number tossAmount, String tossStatus, Order order) {
+        return new Payment(tossPaymentKey, tossOrderId, tossOrderName, tossAmount, tossStatus, order);
     }
 }

--- a/src/main/java/com/example/picket/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/picket/domain/payment/entity/Payment.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "payments")
 @Getter
@@ -25,7 +27,7 @@ public class Payment {
     private String tossOrderName;
 
     @Column(nullable = false)
-    private String tossAmount;
+    private BigDecimal tossAmount;
 
     @Column(nullable = false)
     private String tossStatus;
@@ -38,7 +40,7 @@ public class Payment {
         this.order = order;
     }
 
-    public Payment(String tossPaymentKey, String tossOrderId, String tossOrderName, String tossAmount, String tossStatus) {
+    public Payment(String tossPaymentKey, String tossOrderId, String tossOrderName, BigDecimal tossAmount, String tossStatus) {
         this.tossPaymentKey = tossPaymentKey;
         this.tossOrderId = tossOrderId;
         this.tossOrderName = tossOrderName;
@@ -46,7 +48,7 @@ public class Payment {
         this.tossStatus = tossStatus;
     }
 
-    public static Payment create(String tossPaymentKey, String tossOrderId, String tossOrderName, String tossAmount, String tossStatus) {
+    public static Payment create(String tossPaymentKey, String tossOrderId, String tossOrderName, BigDecimal tossAmount, String tossStatus) {
         return new Payment(tossPaymentKey, tossOrderId, tossOrderName, tossAmount, tossStatus);
     }
 }

--- a/src/main/java/com/example/picket/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/picket/domain/payment/entity/Payment.java
@@ -27,7 +27,7 @@ public class Payment {
     private String tossOrderName;
 
     @Column(nullable = false)
-    private Number tossAmount;
+    private BigDecimal tossAmount;
 
     @Column(nullable = false)
     private String tossStatus;
@@ -40,7 +40,7 @@ public class Payment {
         this.order = order;
     }
 
-    public Payment(String tossPaymentKey, String tossOrderId, String tossOrderName, Number tossAmount, String tossStatus, Order order) {
+    public Payment(String tossPaymentKey, String tossOrderId, String tossOrderName, BigDecimal tossAmount, String tossStatus, Order order) {
         this.tossPaymentKey = tossPaymentKey;
         this.tossOrderId = tossOrderId;
         this.tossOrderName = tossOrderName;
@@ -49,7 +49,7 @@ public class Payment {
         this.order = order;
     }
 
-    public static Payment create(String tossPaymentKey, String tossOrderId, String tossOrderName, Number tossAmount, String tossStatus, Order order) {
+    public static Payment create(String tossPaymentKey, String tossOrderId, String tossOrderName, BigDecimal tossAmount, String tossStatus, Order order) {
         return new Payment(tossPaymentKey, tossOrderId, tossOrderName, tossAmount, tossStatus, order);
     }
 }

--- a/src/main/java/com/example/picket/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/picket/domain/payment/entity/Payment.java
@@ -1,5 +1,6 @@
 package com.example.picket.domain.payment.entity;
 
+import com.example.picket.common.entity.BaseEntity;
 import com.example.picket.domain.order.entity.Order;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -12,7 +13,7 @@ import java.math.BigDecimal;
 @Table(name = "payments")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Payment {
+public class Payment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/picket/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/picket/domain/payment/entity/Payment.java
@@ -1,0 +1,52 @@
+package com.example.picket.domain.payment.entity;
+
+import com.example.picket.domain.order.entity.Order;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String tossPaymentKey;
+
+    @Column(nullable = false)
+    private String tossOrderId;
+
+    @Column(nullable = false)
+    private String tossOrderName;
+
+    @Column(nullable = false)
+    private String tossAmount;
+
+    @Column(nullable = false)
+    private String tossStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+
+    public Payment(String tossPaymentKey, String tossOrderId, String tossOrderName, String tossAmount, String tossStatus) {
+        this.tossPaymentKey = tossPaymentKey;
+        this.tossOrderId = tossOrderId;
+        this.tossOrderName = tossOrderName;
+        this.tossAmount = tossAmount;
+        this.tossStatus = tossStatus;
+    }
+
+    public static Payment create(String tossPaymentKey, String tossOrderId, String tossOrderName, String tossAmount, String tossStatus) {
+        return new Payment(tossPaymentKey, tossOrderId, tossOrderName, tossAmount, tossStatus);
+    }
+}

--- a/src/main/java/com/example/picket/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/picket/domain/payment/repository/PaymentRepository.java
@@ -1,7 +1,13 @@
 package com.example.picket.domain.payment.repository;
 
 import com.example.picket.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    @EntityGraph(attributePaths = {"order"})
+    Optional<Payment> findById(Long paymentId);
 }

--- a/src/main/java/com/example/picket/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/picket/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.example.picket.domain.payment.repository;
+
+import com.example.picket.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/example/picket/domain/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/example/picket/domain/payment/service/PaymentCommandService.java
@@ -1,6 +1,5 @@
 package com.example.picket.domain.payment.service;
 
-import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.order.entity.Order;
 import com.example.picket.domain.payment.entity.Payment;
 import com.example.picket.domain.payment.repository.PaymentRepository;
@@ -10,8 +9,6 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
-
-import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +29,7 @@ public class PaymentCommandService {
         redisTemplate.expire(userIdToSave, 600, TimeUnit.SECONDS);
     }
 
-    public Payment create(String paymentKey, String orderId, String orderName, String status, BigDecimal totalAmount, Order order) {
+    public Payment createPayment(String paymentKey, String orderId, String orderName, String status, BigDecimal totalAmount, Order order) {
         Payment payment = Payment.create(paymentKey, orderId, orderName, totalAmount, status, order);
         return paymentRepository.save(payment);
     }

--- a/src/main/java/com/example/picket/domain/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/example/picket/domain/payment/service/PaymentCommandService.java
@@ -15,7 +15,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
-public class PaymentService {
+public class PaymentCommandService {
 
     private static final String KEY_PREFIX = "PAYMENT-INFO:USER:";
     private final StringRedisTemplate redisTemplate;
@@ -35,10 +35,5 @@ public class PaymentService {
     public Payment create(String paymentKey, String orderId, String orderName, String status, BigDecimal totalAmount, Order order) {
         Payment payment = Payment.create(paymentKey, orderId, orderName, totalAmount, status, order);
         return paymentRepository.save(payment);
-    }
-
-    public Payment getPayment(Long paymentId) {
-        return paymentRepository.findById(paymentId).orElseThrow(
-                () -> new CustomException(NOT_FOUND, "존재하지 않는 Payment입니다."));
     }
 }

--- a/src/main/java/com/example/picket/domain/payment/service/PaymentQueryService.java
+++ b/src/main/java/com/example/picket/domain/payment/service/PaymentQueryService.java
@@ -1,0 +1,26 @@
+package com.example.picket.domain.payment.service;
+
+import com.example.picket.common.exception.CustomException;
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.payment.entity.Payment;
+import com.example.picket.domain.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentQueryService {
+
+    private final PaymentRepository paymentRepository;
+
+    public Payment getPayment(Long paymentId) {
+        return paymentRepository.findById(paymentId).orElseThrow(
+                () -> new CustomException(NOT_FOUND, "존재하지 않는 Payment입니다."));
+    }
+}

--- a/src/main/java/com/example/picket/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/picket/domain/payment/service/PaymentService.java
@@ -1,5 +1,8 @@
 package com.example.picket.domain.payment.service;
 
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.payment.entity.Payment;
+import com.example.picket.domain.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -13,15 +16,21 @@ public class PaymentService {
 
     private static final String KEY_PREFIX = "PAYMENT-INFO:USER:";
     private final StringRedisTemplate redisTemplate;
+    private final PaymentRepository paymentRepository;
 
-    public void temporarySavePaymentInfo(String orderId, BigDecimal amount, Long userId) {
+    public void temporarySavePaymentInfo(String orderId, Number amount, Long userId) {
         String userIdToSave = KEY_PREFIX + userId.toString();
         String orderIdToSave = orderId;
-        BigDecimal amountToSave = amount;
+        Number amountToSave = amount;
 
         redisTemplate.opsForHash().put(userIdToSave, "orderId", orderIdToSave);
         redisTemplate.opsForHash().put(userIdToSave, "amount", amountToSave.toString());
 
         redisTemplate.expire(userIdToSave, 600, TimeUnit.SECONDS);
+    }
+
+    public Payment create(String paymentKey, String orderId, String orderName, String status, Number totalAmount, Order order) {
+        Payment payment = Payment.create(paymentKey, orderId, orderName, totalAmount, status, order);
+        return paymentRepository.save(payment);
     }
 }

--- a/src/main/java/com/example/picket/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/picket/domain/payment/service/PaymentService.java
@@ -1,0 +1,27 @@
+package com.example.picket.domain.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private static final String KEY_PREFIX = "PAYMENT-INFO:USER:";
+    private final StringRedisTemplate redisTemplate;
+
+    public void temporarySavePaymentInfo(String orderId, BigDecimal amount, Long userId) {
+        String userIdToSave = KEY_PREFIX + userId.toString();
+        String orderIdToSave = orderId;
+        BigDecimal amountToSave = amount;
+
+        redisTemplate.opsForHash().put(userIdToSave, "orderId", orderIdToSave);
+        redisTemplate.opsForHash().put(userIdToSave, "amount", amountToSave.toString());
+
+        redisTemplate.expire(userIdToSave, 600, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/example/picket/domain/show/service/ShowDateCommandService.java
+++ b/src/main/java/com/example/picket/domain/show/service/ShowDateCommandService.java
@@ -28,10 +28,16 @@ public class ShowDateCommandService {
         showDateJdbcRepository.saveAllJdbc(showDates);
     }
 
-    public void countUpdate(Long showDateId, int count) {
+    public void countUpdateOnBooking(Long showDateId, int count) {
         ShowDate foundShowDate = showDateRepository.findById(showDateId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND, "공연 날짜를 찾을 수 없습니다."));
         foundShowDate.updateCountOnBooking(count);
+    }
+
+    public void countUpdateOnCancellation(Long showDateId, int count) {
+        ShowDate foundShowDate = showDateRepository.findById(showDateId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND, "공연 날짜를 찾을 수 없습니다."));
+        foundShowDate.updateCountOnCancellation(count);
     }
 
 }

--- a/src/main/java/com/example/picket/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/example/picket/domain/ticket/repository/TicketRepository.java
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import java.util.Optional;
@@ -46,4 +47,7 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     int updateTicketStatusByShowId(@Param("showId") Long showId,
                                    @Param("currentStatus") TicketStatus currentStatus,
                                    @Param("newStatus") TicketStatus newStatus);
+
+    @Query("SELECT SUM(t.price) FROM Ticket t WHERE t.id IN :ticketIds")
+    BigDecimal sumPricesByTicketIds(@Param("ticketIds") List<Long> ticketIds);
 }

--- a/src/main/java/com/example/picket/domain/ticket/service/TicketQueryService.java
+++ b/src/main/java/com/example/picket/domain/ticket/service/TicketQueryService.java
@@ -5,6 +5,8 @@ import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.ticket.entity.Ticket;
 import com.example.picket.domain.ticket.repository.TicketRepository;
+
+import java.math.BigDecimal;
 import java.util.List;
 
 import com.example.picket.domain.user.entity.User;
@@ -63,5 +65,10 @@ public class TicketQueryService {
        if (reservedTicketCount >= show.getTicketsLimitPerUser()) {
            throw new CustomException(CONFLICT, "예매 가능한 티켓 수를 초과합니다.");
        }
+   }
+
+   @Transactional(readOnly = true)
+   public BigDecimal addUpTicketPrice(List<Long> ticketIds) {
+       return ticketRepository.sumPricesByTicketIds(ticketIds);
    }
 }

--- a/src/main/resources/static/checkout.html
+++ b/src/main/resources/static/checkout.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+    <script src="https://js.tosspayments.com/v2/standard"></script>
+</head>
+<body>
+<!-- 결제 UI -->
+<div id="payment-method"></div>
+<!-- 이용약관 UI -->
+<div id="agreement"></div>
+<!-- 결제하기 버튼 -->
+<button class="button" id="payment-button" style="margin-top: 30px">결제하기</button>
+
+<script>
+    main();
+
+    async function main() {
+        const button = document.getElementById("payment-button");
+        const coupon = document.getElementById("coupon-box");
+        // ------  결제위젯 초기화 ------
+        const clientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
+        const tossPayments = TossPayments(clientKey);
+        // 회원 결제
+        const customerKey = "XKwDYa_QHmgRjLFkas1fA";
+        const widgets = tossPayments.widgets({
+            customerKey,
+        });
+        // 비회원 결제
+        // const widgets = tossPayments.widgets({ customerKey: TossPayments.ANONYMOUS });
+
+        // ------ 주문의 결제 금액 설정 ------
+        await widgets.setAmount({
+            currency: "KRW",
+            value: 300,
+        });
+
+        await Promise.all([
+            // ------  결제 UI 렌더링 ------
+            widgets.renderPaymentMethods({
+                selector: "#payment-method",
+                variantKey: "DEFAULT",
+            }),
+            // ------  이용약관 UI 렌더링 ------
+            widgets.renderAgreement({ selector: "#agreement", variantKey: "AGREEMENT" }),
+        ]);
+
+        // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
+        button.addEventListener("click", async function () {
+            await widgets.requestPayment({
+                orderId: "xseyiILfBVbthKjKbKaEG",
+                orderName: "토스 티셔츠 외 2건",
+                successUrl: window.location.origin + "/success.html",
+                failUrl: window.location.origin + "/fail.html",
+                customerEmail: "customer123@gmail.com",
+                customerName: "김토스",
+                customerMobilePhone: "01012341234",
+            });
+        });
+    }
+</script>
+</body>
+</html>
+
+

--- a/src/main/resources/static/checkout.html
+++ b/src/main/resources/static/checkout.html
@@ -39,6 +39,7 @@
         // const widgets = tossPayments.widgets({ customerKey: TossPayments.ANONYMOUS });
 
         // ------ 주문의 결제 금액 설정 ------
+        // value에 결제할 금액을 설정하고 프로젝트를 시작하세요
         await widgets.setAmount({
             currency: "KRW",
             value: 600,

--- a/src/main/resources/static/checkout.html
+++ b/src/main/resources/static/checkout.html
@@ -13,6 +13,15 @@
 <button class="button" id="payment-button" style="margin-top: 30px">결제하기</button>
 
 <script>
+    // 랜덤한 주문 ID 생성 함수
+    function generateRandomOrderId() {
+        // 현재 시간을 밀리초로 가져와 문자열로 변환
+        const timestamp = new Date().getTime().toString();
+        // 랜덤 문자열 생성 (영문 대소문자와 숫자 조합)
+        const randomChars = Math.random().toString(36).substring(2, 10);
+        // 타임스탬프와 랜덤 문자를 합쳐서 고유한 ID 생성
+        return randomChars + timestamp.substring(timestamp.length - 6);
+    }
     main();
 
     async function main() {
@@ -47,8 +56,9 @@
 
         // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
         button.addEventListener("click", async function () {
+            const orderId = generateRandomOrderId();
             await widgets.requestPayment({
-                orderId: "xseyiILfBVbthKjKbKaEH",
+                orderId: orderId,
                 orderName: "토스 티셔츠 외 2건",
                 successUrl: window.location.origin + "/success.html",
                 failUrl: window.location.origin + "/fail.html",

--- a/src/main/resources/static/checkout.html
+++ b/src/main/resources/static/checkout.html
@@ -41,7 +41,7 @@
         // ------ 주문의 결제 금액 설정 ------
         await widgets.setAmount({
             currency: "KRW",
-            value: 300,
+            value: 600,
         });
 
         await Promise.all([
@@ -59,11 +59,11 @@
             const orderId = generateRandomOrderId();
             await widgets.requestPayment({
                 orderId: orderId,
-                orderName: "토스 티셔츠 외 2건",
+                orderName: "2026 FIFA 월드컵 아시아 3차 예선 요르단전 수원월드컵경기장 E17",
                 successUrl: window.location.origin + "/success.html",
                 failUrl: window.location.origin + "/fail.html",
                 customerEmail: "customer123@gmail.com",
-                customerName: "김토스",
+                customerName: "김픽켓",
                 customerMobilePhone: "01012341234",
             });
         });

--- a/src/main/resources/static/checkout.html
+++ b/src/main/resources/static/checkout.html
@@ -48,7 +48,7 @@
         // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
         button.addEventListener("click", async function () {
             await widgets.requestPayment({
-                orderId: "xseyiILfBVbthKjKbKaEG",
+                orderId: "xseyiILfBVbthKjKbKaEH",
                 orderName: "토스 티셔츠 외 2건",
                 successUrl: window.location.origin + "/success.html",
                 failUrl: window.location.origin + "/fail.html",

--- a/src/main/resources/static/fail.html
+++ b/src/main/resources/static/fail.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+</head>
+
+<body>
+<h2> 결제 실패 </h2>
+<p id="code"></p>
+<p id="message"></p>
+</body>
+</html>
+
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+
+    const codeElement = document.getElementById("code");
+    const messageElement = document.getElementById("message");
+
+    codeElement.textContent = "에러코드: " + urlParams.get("code");
+    messageElement.textContent = "실패 사유: " + urlParams.get("message");
+</script>

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,132 @@
+.w-100 {
+    width: 100%;
+}
+
+.h-100 {
+    height: 100%;
+}
+
+a {
+    text-decoration: none;
+    text-align: center;
+}
+
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 24px;
+    overflow: auto;
+}
+
+.max-w-540 {
+    max-width: 540px;
+}
+
+.btn-wrapper {
+    padding: 0 24px;
+}
+
+.btn {
+    padding: 11px 22px;
+    border: none;
+    border-radius:  8px;
+
+    background-color: #f2f4f6;
+    color: #4e5968;
+    font-weight: 600;
+    font-size: 17px;
+    cursor: pointer;
+}
+
+.btn.primary {
+    background-color: #3282f6;
+    color: #f9fcff;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.flex {
+    display: flex;
+}
+
+.flex-column {
+    display: flex;
+    flex-direction: column;
+}
+
+.justify-center {
+    justify-content: center;
+}
+
+.justify-between {
+    justify-content: space-between;
+}
+
+.align-center {
+    align-items: center;
+}
+
+.confirm-loading {
+    margin-top: 72px;
+    height: 400px;
+    justify-content: space-between;
+}
+
+
+.confirm-success {
+    display: none;
+    margin-top: 72px;
+}
+
+.button-group {
+    margin-top: 32px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 16px;
+}
+
+.title {
+    margin-top: 32px;
+    margin-bottom: 0;
+    color: #191f28;
+    font-weight: bold;
+    font-size: 24px;
+}
+
+.description {
+    margin-top: 8px;
+    color: #4e5968;
+    font-size: 17px;
+    font-weight: 500;
+}
+
+.response-section {
+    margin-top: 60px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    font-size: 20px;
+}
+
+.response-section .response-label {
+    font-weight: 600;
+    color: #333d48;
+    font-size: 17px;
+}
+
+.response-section .response-text {
+    font-weight: 500;
+    color: #4e5968;
+    font-size: 17px;
+    padding-left: 16px;
+    word-break: break-word;
+    text-align: right;
+}
+
+.color-grey {
+    color: #b0b8c1;
+}

--- a/src/main/resources/static/success.html
+++ b/src/main/resources/static/success.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+</head>
+<body>
+<h2>결제 성공</h2>
+<p id="paymentKey"></p>
+<p id="orderId"></p>
+<p id="amount"></p>
+
+<script>
+    // 쿼리 파라미터 값이 결제 요청할 때 보낸 데이터와 동일한지 반드시 확인하세요.
+    // 클라이언트에서 결제 금액을 조작하는 행위를 방지할 수 있습니다.
+    const urlParams = new URLSearchParams(window.location.search);
+    const paymentKey = urlParams.get("paymentKey");
+    const orderId = urlParams.get("orderId");
+    const amount = urlParams.get("amount");
+
+    // async function confirm() {
+    //     const requestData = {
+    //         paymentKey: paymentKey,
+    //         orderId: orderId,
+    //         amount: amount,
+    //     };
+    //
+    //     // const response = await fetch("/confirm", {
+    //     //     method: "POST",
+    //     //     headers: {
+    //     //         "Content-Type": "application/json",
+    //     //     },
+    //     //     body: JSON.stringify(requestData),
+    //     // });
+    //     //
+    //     // const json = await response.json();
+    //
+    //     // if (!response.ok) {
+    //     //     // 결제 실패 비즈니스 로직을 구현하세요.
+    //     //     console.log(json);
+    //     //     window.location.href = `/fail?message=${json.message}&code=${json.code}`;
+    //     // }
+    //     //
+    //     // // 결제 성공 비즈니스 로직을 구현하세요.
+    //     // console.log(json);
+    // }
+    // confirm();
+    //
+    // const paymentKeyElement = document.getElementById("paymentKey");
+    // const orderIdElement = document.getElementById("orderId");
+    // const amountElement = document.getElementById("amount");
+    //
+    // orderIdElement.textContent = "주문번호: " + orderId;
+    // amountElement.textContent = "결제 금액: " + amount;
+    // paymentKeyElement.textContent = "paymentKey: " + paymentKey;
+</script>
+</body>
+</html>

--- a/src/main/resources/static/success.html
+++ b/src/main/resources/static/success.html
@@ -17,6 +17,22 @@
     const orderId = urlParams.get("orderId");
     const amount = urlParams.get("amount");
 
+    // async function temporarySave() {
+    //     const requestData = {
+    //         orderId: orderId,
+    //         amount: amount,
+    //     };
+    //
+    //     const response = await fetch("/api/v2/payments/temporary-save", {
+    //         method: "POST",
+    //         headers: {
+    //             "Content-Type": "application/json",
+    //         },
+    //         body: JSON.stringify(requestData),
+    //     });
+    // }
+    //
+    // temporarySave();
     // async function confirm() {
     //     const requestData = {
     //         paymentKey: paymentKey,
@@ -45,13 +61,13 @@
     // }
     // confirm();
     //
-    // const paymentKeyElement = document.getElementById("paymentKey");
-    // const orderIdElement = document.getElementById("orderId");
-    // const amountElement = document.getElementById("amount");
-    //
-    // orderIdElement.textContent = "주문번호: " + orderId;
-    // amountElement.textContent = "결제 금액: " + amount;
-    // paymentKeyElement.textContent = "paymentKey: " + paymentKey;
+    const paymentKeyElement = document.getElementById("paymentKey");
+    const orderIdElement = document.getElementById("orderId");
+    const amountElement = document.getElementById("amount");
+
+    orderIdElement.textContent = "주문번호: " + orderId;
+    amountElement.textContent = "결제 금액: " + amount;
+    paymentKeyElement.textContent = "paymentKey: " + paymentKey;
 </script>
 </body>
 </html>

--- a/src/test/java/com/example/picket/domain/booking/service/BookingServiceTest.java
+++ b/src/test/java/com/example/picket/domain/booking/service/BookingServiceTest.java
@@ -1,122 +1,205 @@
-//package com.example.picket.domain.booking.service;
-//
-//import com.example.picket.common.enums.*;
-//import com.example.picket.common.exception.CustomException;
-//import com.example.picket.domain.order.entity.Order;
-//import com.example.picket.domain.order.service.OrderCommandService;
-//import com.example.picket.domain.seat.entity.Seat;
-//import com.example.picket.domain.seat_holding.service.SeatHoldingService;
-//import com.example.picket.domain.show.entity.Show;
-//import com.example.picket.domain.show.entity.ShowDate;
-//import com.example.picket.domain.show.service.ShowDateCommandService;
-//import com.example.picket.domain.show.service.ShowDateQueryService;
-//import com.example.picket.domain.show.service.ShowQueryService;
-//import com.example.picket.domain.ticket.entity.Ticket;
-//import com.example.picket.domain.ticket.service.TicketCommandService;
-//import com.example.picket.domain.ticket.service.TicketQueryService;
-//import com.example.picket.domain.user.entity.User;
-//import com.example.picket.domain.user.service.UserQueryService;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.invocation.InvocationOnMock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.mockito.stubbing.Answer;
-//import org.redisson.api.RLock;
-//import org.redisson.api.RedissonClient;
-//
-//import java.math.BigDecimal;
-//import java.time.LocalDate;
-//import java.time.LocalDateTime;
-//import java.time.LocalTime;
-//import java.util.Arrays;
-//import java.util.List;
-//import java.util.concurrent.*;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class BookingServiceTest {
-//
-//    @Mock private RedissonClient redissonClient;
-//    @Mock private RLock rLock;
-//    @Mock private SeatHoldingService seatHoldingService;
-//    @Mock private ShowQueryService showQueryService;
-//    @Mock private UserQueryService userQueryService;
-//    @Mock private ShowDateQueryService showDateQueryService;
-//    @Mock private TicketQueryService ticketQueryService;
-//    @Mock private OrderCommandService orderCommandService;
-//    @Mock private TicketCommandService ticketCommandService;
-//    @Mock private ShowDateCommandService showDateCommandService;
-//
-//    @InjectMocks
-//    private BookingService bookingService;
-//
-//    @Test
-//    void 예매에_성공한다() throws InterruptedException {
-//        // given
-//        Long showId = 1L;
-//        Long showDateId = 1L;
-//        Long userId = 1L;
-//        List<Long> seatIds = List.of(10L, 11L);
-//
-//        Show mockShow = mock(Show.class);
-//        when(mockShow.getReservationStart()).thenReturn(LocalDateTime.now().minusHours(1));
-//        when(mockShow.getReservationEnd()).thenReturn(LocalDateTime.now().plusHours(1));
-//
-//        User mockUser = mock(User.class);
-//        List<Ticket> mockTickets = List.of(mock(Ticket.class));
-//        Order mockOrder = mock(Order.class);
-//
-//        when(showQueryService.getShow(showId)).thenReturn(mockShow);
-//        when(userQueryService.getUser(userId)).thenReturn(mockUser);
-//
-//        doNothing().when(seatHoldingService).seatHoldingCheck(userId, seatIds);
-//        doNothing().when(ticketQueryService).checkTicketLimit(mockUser, mockShow);
-//
-//        when(ticketCommandService.createTicket(mockUser, mockShow, seatIds)).thenReturn(mockTickets);
-//        when(orderCommandService.createOrder(mockUser, mockTickets)).thenReturn(mockOrder);
-//
-//        doNothing().when(showDateCommandService).countUpdate(showDateId, seatIds.size());
-//        doNothing().when(seatHoldingService).seatHoldingUnLock(seatIds);
-//
-//        // when
-//        Order result = bookingService.booking(showId, showDateId, userId, seatIds);
-//
-//        // then
-//        assertThat(result).isEqualTo(mockOrder);
-//    }
-//
-//    @Test
-//    void 예매취소에_성공한다() throws InterruptedException {
-//        // given
-//        Long showId = 1L;
-//        Long showDateId = 1L;
-//        Long userId = 1L;
-//        List<Long> seatIds = List.of(10L, 11L);
-//        List<Long> ticketIds = List.of(1L, 2L);
-//
-//        ShowDate mockShowDate = mock(ShowDate.class);
-//        when(mockShowDate.getDate()).thenReturn(LocalDate.now().plusDays(1));
-//
-//        User mockUser = mock(User.class);
-//        List<Ticket> mockTickets = List.of(mock(Ticket.class));
-//
-//        when(showDateQueryService.getShowDate(showDateId)).thenReturn(mockShowDate);
-//        when(userQueryService.getUser(userId)).thenReturn(mockUser);
-//
-//        when(ticketCommandService.deleteTicket(mockUser, ticketIds)).thenReturn(mockTickets);
-//
-//        doNothing().when(showDateCommandService).countUpdate(showDateId, seatIds.size());
-//
-//        // when
-//        List<Ticket> result = bookingService.cancelBooking(showId, showDateId, userId, ticketIds);
-//
-//        // then
-//        assertThat(result).isEqualTo(mockTickets);
-//    }
-//}
+package com.example.picket.domain.booking.service;
+
+import com.example.picket.common.enums.OrderStatus;
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.order.service.OrderCommandService;
+import com.example.picket.domain.payment.entity.Payment;
+import com.example.picket.domain.payment.service.PaymentCommandService;
+import com.example.picket.domain.payment.service.PaymentQueryService;
+import com.example.picket.domain.seat_holding.service.SeatHoldingService;
+import com.example.picket.domain.show.entity.Show;
+import com.example.picket.domain.show.entity.ShowDate;
+import com.example.picket.domain.show.service.ShowDateCommandService;
+import com.example.picket.domain.show.service.ShowDateQueryService;
+import com.example.picket.domain.show.service.ShowQueryService;
+import com.example.picket.domain.ticket.entity.Ticket;
+import com.example.picket.domain.ticket.service.TicketCommandService;
+import com.example.picket.domain.ticket.service.TicketQueryService;
+import com.example.picket.domain.user.entity.User;
+import com.example.picket.domain.user.service.UserQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookingServiceTest {
+
+    private static final String TOSS_PAY_BASE_URL = "https://api.tosspayments.com/v1/payments/";
+
+    @Mock private SeatHoldingService seatHoldingService;
+    @Mock private ShowQueryService showQueryService;
+    @Mock private UserQueryService userQueryService;
+    @Mock private ShowDateQueryService showDateQueryService;
+    @Mock private TicketQueryService ticketQueryService;
+    @Mock private OrderCommandService orderCommandService;
+    @Mock private TicketCommandService ticketCommandService;
+    @Mock private ShowDateCommandService showDateCommandService;
+    @Mock private PaymentCommandService paymentCommandService;
+    @Mock private PaymentQueryService paymentQueryService;
+    @Mock private StringRedisTemplate stringRedisTemplate;
+    @Mock private WebClient webClient;
+    @Mock private HashOperations<String, Object, Object> hashOperations;
+
+    @InjectMocks
+    private BookingService bookingService;
+
+    private final Long showId = 1L;
+    private final Long showDateId = 2L;
+    private final Long userId = 3L;
+    private final List<Long> seatIds = Arrays.asList(10L, 11L, 12L);
+    private final String paymentKey = "payment_key_123";
+    private final String orderId = "order_id_123";
+    private final BigDecimal amount = new BigDecimal("30000");
+
+    @Test
+    @DisplayName("성공적으로 예매할 수 있다.")
+    void successBooking() throws InterruptedException {
+        // given
+        String key = "PAYMENT-INFO:USER:" + userId;
+        when(hashOperations.get(key, "orderId")).thenReturn(orderId);
+        when(hashOperations.get(key, "amount")).thenReturn(amount.toString());
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("paymentKey", "toss_payment_key_123");
+        responseBody.put("orderId", "order_id_123");
+        responseBody.put("orderName", "테스트 주문");
+        responseBody.put("status", "DONE");
+        responseBody.put("totalAmount", 30000);
+
+        WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+        WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+        WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+        WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+        when(webClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(TOSS_PAY_BASE_URL + "/confirm")).thenReturn(requestBodySpec);
+        when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+        // 이 부분에서 정확한 헤더값을 검증하고 싶다면 ArgumentMatcher 사용
+        when(requestBodySpec.header(eq("Authorization"), anyString())).thenReturn(requestBodySpec);
+        // 요청 본문 값을 검증하고 싶다면 ArgumentCaptor 사용
+        when(requestBodySpec.bodyValue(any())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(Map.class)).thenReturn(Mono.just(responseBody));
+
+        Show show = mock(Show.class);
+        User user = mock(User.class);
+        List<Ticket> tickets = Arrays.asList(mock(Ticket.class), mock(Ticket.class));
+        Order order = mock(Order.class);
+        Payment payment = mock(Payment.class);
+
+        when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(show.getReservationStart()).thenReturn(LocalDateTime.now().minusDays(1));
+        when(show.getReservationEnd()).thenReturn(LocalDateTime.now().plusDays(1));
+        when(showQueryService.getShow(showId)).thenReturn(show);
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        doNothing().when(seatHoldingService).seatHoldingCheck(userId, seatIds);
+        doNothing().when(ticketQueryService).checkTicketLimit(user, show);
+        when(ticketCommandService.createTicket(user, show, seatIds)).thenReturn(tickets);
+        when(orderCommandService.createOrder(user, tickets)).thenReturn(order);
+        when(paymentCommandService.createPayment(anyString(), anyString(), anyString(), anyString(), any(BigDecimal.class), eq(order))).thenReturn(payment);
+        doNothing().when(showDateCommandService).countUpdateOnBooking(showDateId, seatIds.size());
+        doNothing().when(seatHoldingService).seatHoldingUnLock(seatIds);
+
+        // when
+        Order result = bookingService.booking(showId, showDateId, userId, seatIds, paymentKey, orderId, amount);
+
+        // then
+        assertNotNull(result);
+        assertEquals(order, result);
+
+        verify(showQueryService).getShow(showId);
+        verify(userQueryService).getUser(userId);
+        verify(seatHoldingService).seatHoldingCheck(userId, seatIds);
+        verify(ticketQueryService).checkTicketLimit(user, show);
+        verify(ticketCommandService).createTicket(user, show, seatIds);
+        verify(orderCommandService).createOrder(user, tickets);
+        verify(paymentCommandService).createPayment(anyString(), anyString(), anyString(), anyString(), any(BigDecimal.class), eq(order));
+        verify(showDateCommandService).countUpdateOnBooking(showDateId, seatIds.size());
+        verify(seatHoldingService).seatHoldingUnLock(seatIds);
+        verify(stringRedisTemplate).delete(key);
+
+    }
+
+    @Test
+    void successCancelBooking() throws InterruptedException {
+        // given
+        Long paymentId = 1L;
+        String cancelReason = "고객 요청";
+        BigDecimal cancelAmount = new BigDecimal("30000");
+        User user = mock(User.class);
+        Order order = mock(Order.class);
+        Payment payment = mock(Payment.class);
+        ShowDate showDate = mock(ShowDate.class);
+        List<Ticket> canceledTickets = Arrays.asList(mock(Ticket.class), mock(Ticket.class));
+
+        Map<String, Object> cancelResponseBody = new HashMap<>();
+        List<Map<String, Object>> cancels = new ArrayList<>();
+        Map<String, Object> cancelInfo = new HashMap<>();
+        cancelInfo.put("cancelAmount", 30000);
+        cancels.add(cancelInfo);
+        cancelResponseBody.put("cancels", cancels);
+        cancelResponseBody.put("status", "CANCELED");
+        cancelResponseBody.put("paymentKey", "toss_payment_key_123");
+        cancelResponseBody.put("orderId", "order_id_123");
+        cancelResponseBody.put("orderName", "테스트 주문");
+        cancelResponseBody.put("totalAmount", 30000);
+
+        WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+        WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+        WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+        WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+        when(webClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(TOSS_PAY_BASE_URL + "/" + paymentKey + "/cancel")).thenReturn(requestBodySpec);
+        when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+        when(requestBodySpec.header(eq("Authorization"), anyString())).thenReturn(requestBodySpec);
+        when(requestBodySpec.bodyValue(any())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(Map.class)).thenReturn(Mono.just(cancelResponseBody));
+
+        when(paymentCommandService.createPayment(anyString(), anyString(), anyString(), anyString(), any(BigDecimal.class), eq(order))).thenReturn(payment);
+        when(ticketQueryService.addUpTicketPrice(seatIds)).thenReturn(cancelAmount);
+        when(paymentQueryService.getPayment(paymentId)).thenReturn(payment);
+        when(payment.getTossPaymentKey()).thenReturn(paymentKey);
+        when(payment.getOrder()).thenReturn(order);
+        when(showDateQueryService.getShowDate(showDateId)).thenReturn(showDate);
+        when(userQueryService.getUser(userId)).thenReturn(user);
+        when(ticketCommandService.deleteTicket(user, seatIds)).thenReturn(canceledTickets);
+
+        when(showDate.getDate()).thenReturn(LocalDate.now().plusDays(1));
+
+        when(order.getTotalPrice()).thenReturn(cancelAmount);
+
+        // when
+        List<Ticket> result = bookingService.cancelBooking(showId, showDateId, userId, paymentId, seatIds, cancelReason);
+
+        // then
+        assertEquals(canceledTickets, result);
+        verify(paymentCommandService).createPayment(anyString(), anyString(), anyString(), anyString(), any(BigDecimal.class), eq(order));
+        verify(ticketCommandService).deleteTicket(user, seatIds);
+        verify(showDateCommandService).countUpdateOnCancellation(showDateId, seatIds.size());
+        verify(order).updateTotalPrice(BigDecimal.ZERO);
+        verify(order).updateOrderStatus(OrderStatus.ORDER_CANCELED);
+    }
+}

--- a/src/test/java/com/example/picket/domain/booking/service/BookingServiceTest.java
+++ b/src/test/java/com/example/picket/domain/booking/service/BookingServiceTest.java
@@ -1,122 +1,122 @@
-package com.example.picket.domain.booking.service;
-
-import com.example.picket.common.enums.*;
-import com.example.picket.common.exception.CustomException;
-import com.example.picket.domain.order.entity.Order;
-import com.example.picket.domain.order.service.OrderCommandService;
-import com.example.picket.domain.seat.entity.Seat;
-import com.example.picket.domain.seat_holding.service.SeatHoldingService;
-import com.example.picket.domain.show.entity.Show;
-import com.example.picket.domain.show.entity.ShowDate;
-import com.example.picket.domain.show.service.ShowDateCommandService;
-import com.example.picket.domain.show.service.ShowDateQueryService;
-import com.example.picket.domain.show.service.ShowQueryService;
-import com.example.picket.domain.ticket.entity.Ticket;
-import com.example.picket.domain.ticket.service.TicketCommandService;
-import com.example.picket.domain.ticket.service.TicketQueryService;
-import com.example.picket.domain.user.entity.User;
-import com.example.picket.domain.user.service.UserQueryService;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-@ExtendWith(MockitoExtension.class)
-class BookingServiceTest {
-
-    @Mock private RedissonClient redissonClient;
-    @Mock private RLock rLock;
-    @Mock private SeatHoldingService seatHoldingService;
-    @Mock private ShowQueryService showQueryService;
-    @Mock private UserQueryService userQueryService;
-    @Mock private ShowDateQueryService showDateQueryService;
-    @Mock private TicketQueryService ticketQueryService;
-    @Mock private OrderCommandService orderCommandService;
-    @Mock private TicketCommandService ticketCommandService;
-    @Mock private ShowDateCommandService showDateCommandService;
-
-    @InjectMocks
-    private BookingService bookingService;
-
-    @Test
-    void 예매에_성공한다() throws InterruptedException {
-        // given
-        Long showId = 1L;
-        Long showDateId = 1L;
-        Long userId = 1L;
-        List<Long> seatIds = List.of(10L, 11L);
-
-        Show mockShow = mock(Show.class);
-        when(mockShow.getReservationStart()).thenReturn(LocalDateTime.now().minusHours(1));
-        when(mockShow.getReservationEnd()).thenReturn(LocalDateTime.now().plusHours(1));
-
-        User mockUser = mock(User.class);
-        List<Ticket> mockTickets = List.of(mock(Ticket.class));
-        Order mockOrder = mock(Order.class);
-
-        when(showQueryService.getShow(showId)).thenReturn(mockShow);
-        when(userQueryService.getUser(userId)).thenReturn(mockUser);
-
-        doNothing().when(seatHoldingService).seatHoldingCheck(userId, seatIds);
-        doNothing().when(ticketQueryService).checkTicketLimit(mockUser, mockShow);
-
-        when(ticketCommandService.createTicket(mockUser, mockShow, seatIds)).thenReturn(mockTickets);
-        when(orderCommandService.createOrder(mockUser, mockTickets)).thenReturn(mockOrder);
-
-        doNothing().when(showDateCommandService).countUpdate(showDateId, seatIds.size());
-        doNothing().when(seatHoldingService).seatHoldingUnLock(seatIds);
-
-        // when
-        Order result = bookingService.booking(showId, showDateId, userId, seatIds);
-
-        // then
-        assertThat(result).isEqualTo(mockOrder);
-    }
-
-    @Test
-    void 예매취소에_성공한다() throws InterruptedException {
-        // given
-        Long showId = 1L;
-        Long showDateId = 1L;
-        Long userId = 1L;
-        List<Long> seatIds = List.of(10L, 11L);
-        List<Long> ticketIds = List.of(1L, 2L);
-
-        ShowDate mockShowDate = mock(ShowDate.class);
-        when(mockShowDate.getDate()).thenReturn(LocalDate.now().plusDays(1));
-
-        User mockUser = mock(User.class);
-        List<Ticket> mockTickets = List.of(mock(Ticket.class));
-
-        when(showDateQueryService.getShowDate(showDateId)).thenReturn(mockShowDate);
-        when(userQueryService.getUser(userId)).thenReturn(mockUser);
-
-        when(ticketCommandService.deleteTicket(mockUser, ticketIds)).thenReturn(mockTickets);
-
-        doNothing().when(showDateCommandService).countUpdate(showDateId, seatIds.size());
-
-        // when
-        List<Ticket> result = bookingService.cancelBooking(showId, showDateId, userId, ticketIds);
-
-        // then
-        assertThat(result).isEqualTo(mockTickets);
-    }
-}
+//package com.example.picket.domain.booking.service;
+//
+//import com.example.picket.common.enums.*;
+//import com.example.picket.common.exception.CustomException;
+//import com.example.picket.domain.order.entity.Order;
+//import com.example.picket.domain.order.service.OrderCommandService;
+//import com.example.picket.domain.seat.entity.Seat;
+//import com.example.picket.domain.seat_holding.service.SeatHoldingService;
+//import com.example.picket.domain.show.entity.Show;
+//import com.example.picket.domain.show.entity.ShowDate;
+//import com.example.picket.domain.show.service.ShowDateCommandService;
+//import com.example.picket.domain.show.service.ShowDateQueryService;
+//import com.example.picket.domain.show.service.ShowQueryService;
+//import com.example.picket.domain.ticket.entity.Ticket;
+//import com.example.picket.domain.ticket.service.TicketCommandService;
+//import com.example.picket.domain.ticket.service.TicketQueryService;
+//import com.example.picket.domain.user.entity.User;
+//import com.example.picket.domain.user.service.UserQueryService;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.invocation.InvocationOnMock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.mockito.stubbing.Answer;
+//import org.redisson.api.RLock;
+//import org.redisson.api.RedissonClient;
+//
+//import java.math.BigDecimal;
+//import java.time.LocalDate;
+//import java.time.LocalDateTime;
+//import java.time.LocalTime;
+//import java.util.Arrays;
+//import java.util.List;
+//import java.util.concurrent.*;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.junit.jupiter.api.Assertions.*;
+//import static org.mockito.Mockito.*;
+//
+//@ExtendWith(MockitoExtension.class)
+//class BookingServiceTest {
+//
+//    @Mock private RedissonClient redissonClient;
+//    @Mock private RLock rLock;
+//    @Mock private SeatHoldingService seatHoldingService;
+//    @Mock private ShowQueryService showQueryService;
+//    @Mock private UserQueryService userQueryService;
+//    @Mock private ShowDateQueryService showDateQueryService;
+//    @Mock private TicketQueryService ticketQueryService;
+//    @Mock private OrderCommandService orderCommandService;
+//    @Mock private TicketCommandService ticketCommandService;
+//    @Mock private ShowDateCommandService showDateCommandService;
+//
+//    @InjectMocks
+//    private BookingService bookingService;
+//
+//    @Test
+//    void 예매에_성공한다() throws InterruptedException {
+//        // given
+//        Long showId = 1L;
+//        Long showDateId = 1L;
+//        Long userId = 1L;
+//        List<Long> seatIds = List.of(10L, 11L);
+//
+//        Show mockShow = mock(Show.class);
+//        when(mockShow.getReservationStart()).thenReturn(LocalDateTime.now().minusHours(1));
+//        when(mockShow.getReservationEnd()).thenReturn(LocalDateTime.now().plusHours(1));
+//
+//        User mockUser = mock(User.class);
+//        List<Ticket> mockTickets = List.of(mock(Ticket.class));
+//        Order mockOrder = mock(Order.class);
+//
+//        when(showQueryService.getShow(showId)).thenReturn(mockShow);
+//        when(userQueryService.getUser(userId)).thenReturn(mockUser);
+//
+//        doNothing().when(seatHoldingService).seatHoldingCheck(userId, seatIds);
+//        doNothing().when(ticketQueryService).checkTicketLimit(mockUser, mockShow);
+//
+//        when(ticketCommandService.createTicket(mockUser, mockShow, seatIds)).thenReturn(mockTickets);
+//        when(orderCommandService.createOrder(mockUser, mockTickets)).thenReturn(mockOrder);
+//
+//        doNothing().when(showDateCommandService).countUpdate(showDateId, seatIds.size());
+//        doNothing().when(seatHoldingService).seatHoldingUnLock(seatIds);
+//
+//        // when
+//        Order result = bookingService.booking(showId, showDateId, userId, seatIds);
+//
+//        // then
+//        assertThat(result).isEqualTo(mockOrder);
+//    }
+//
+//    @Test
+//    void 예매취소에_성공한다() throws InterruptedException {
+//        // given
+//        Long showId = 1L;
+//        Long showDateId = 1L;
+//        Long userId = 1L;
+//        List<Long> seatIds = List.of(10L, 11L);
+//        List<Long> ticketIds = List.of(1L, 2L);
+//
+//        ShowDate mockShowDate = mock(ShowDate.class);
+//        when(mockShowDate.getDate()).thenReturn(LocalDate.now().plusDays(1));
+//
+//        User mockUser = mock(User.class);
+//        List<Ticket> mockTickets = List.of(mock(Ticket.class));
+//
+//        when(showDateQueryService.getShowDate(showDateId)).thenReturn(mockShowDate);
+//        when(userQueryService.getUser(userId)).thenReturn(mockUser);
+//
+//        when(ticketCommandService.deleteTicket(mockUser, ticketIds)).thenReturn(mockTickets);
+//
+//        doNothing().when(showDateCommandService).countUpdate(showDateId, seatIds.size());
+//
+//        // when
+//        List<Ticket> result = bookingService.cancelBooking(showId, showDateId, userId, ticketIds);
+//
+//        // then
+//        assertThat(result).isEqualTo(mockTickets);
+//    }
+//}

--- a/src/test/java/com/example/picket/domain/payment/service/PaymentCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/payment/service/PaymentCommandServiceTest.java
@@ -1,0 +1,71 @@
+package com.example.picket.domain.payment.service;
+
+import com.example.picket.domain.order.entity.Order;
+import com.example.picket.domain.payment.entity.Payment;
+import com.example.picket.domain.payment.repository.PaymentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCommandServiceTest {
+
+    @InjectMocks
+    private PaymentCommandService paymentCommandService;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    @Test
+    @DisplayName("결제정보를 임시로 저장 할 수 있다.")
+    void canTemporarilySavePaymentInfo() {
+        // given
+        String orderId = "dafadsfasd";
+        BigDecimal amount = new BigDecimal("100");
+        Long userId = 1L;
+        String key = "PAYMENT-INFO:USER:" + userId;
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+
+        // when
+        paymentCommandService.temporarySavePaymentInfo(orderId, amount, userId);
+
+        // then
+        verify(hashOperations).put(key, "orderId", orderId);
+        verify(hashOperations).put(key, "amount", amount.toString());
+        verify(redisTemplate).expire(key, 600, TimeUnit.SECONDS);
+    }
+
+    @Test
+    @DisplayName("Payment를 성공적으로 저장할 수 있다.")
+    void canCreatePayment() {
+        // given
+        String paymentKey = "qdfqdfadsf";
+        String orderId = "dafadsfasd";
+        String orderName = "레베카 VIP S12";
+        BigDecimal amount = new BigDecimal("100");
+        String status = "DONE";
+        Order orderMock = mock(Order.class);
+
+        // when
+        paymentCommandService.createPayment(paymentKey, orderId, orderName, status, amount, orderMock);
+
+        // then
+        verify(paymentRepository).save(any(Payment.class));
+    }
+}

--- a/src/test/java/com/example/picket/domain/payment/service/PaymentQueryServiceTest.java
+++ b/src/test/java/com/example/picket/domain/payment/service/PaymentQueryServiceTest.java
@@ -1,0 +1,42 @@
+package com.example.picket.domain.payment.service;
+
+import com.example.picket.domain.payment.entity.Payment;
+import com.example.picket.domain.payment.repository.PaymentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentQueryServiceTest {
+
+    @InjectMocks
+    private PaymentQueryService paymentQueryService;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Test
+    @DisplayName("성공적으로 Payment를 조회할 수 있다.")
+    void canGetPayment() {
+        // given
+        Long paymentId = 1L;
+        Payment mockPayment = mock(Payment.class);
+        when(paymentRepository.findById(paymentId)).thenReturn(Optional.of(mockPayment));
+
+        // when
+        Payment result= paymentQueryService.getPayment(paymentId);
+
+        // then
+        assertNotNull(result);
+        verify(paymentRepository).findById(paymentId);
+    }
+
+}

--- a/src/test/java/com/example/picket/domain/show/service/ShowDateCommandServiceTest.java
+++ b/src/test/java/com/example/picket/domain/show/service/ShowDateCommandServiceTest.java
@@ -83,7 +83,7 @@ class ShowDateCommandServiceTest {
             given(showDateRepository.findById(showDateId)).willReturn(Optional.of(showDate));
 
             // when
-            showDateCommandService.countUpdate(showDateId, 1);
+            showDateCommandService.countUpdateOnBooking(showDateId, 1);
 
             // then
             assertEquals(showDate.getAvailableSeatCount(), 99);


### PR DESCRIPTION
📌 반영 브랜치
feat/payment -> dev

✅ 작업 내용
좌석 선점 후 결제 정보 인증 -> 락 획득 -> 결제 승인, 기존 예매로직 -> 락해제
 순서로 트랜잭션 설계하여 결제 연동 하였습니다.
 
🎯 단독 테스트 결과

BookingService 단위테스트 확인하였습니다.
Swagger를 이용한 통합테스트로 결제 인증, 승인 확인하였습니다.

✨ 참고사항
티켓을 2장 예매했을 경우 부분 취소를 2번하여 모든 금액을 환불 받았을 경우 order에 totalPrice가 0으로 업데이트 되고 status가 CANCELED로 변경됩니다.
1장만 취소했을 경우엔 환불받은 금액을 order의 totalPrice에서 차감합니다. status는 COMPLETE로 유지됩니다.
또한 paymentKey, orderId, amout는 결제 요청 시 마다 응답되어 변경되는 값으로 swagger example에 따로 값을 명시하지 않았습니다.

🚨 연관 이슈
closes #125