### PR TITLE
Refactor : S3 업로드 MultipartFile 방식 변경, yml 파일 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,9 @@ jobs:
           AWS_S3_IMAGE_BUCKET: ${{ secrets.AWS_S3_IMAGE_BUCKET }}
           AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY  }}
+          AWS_SES_ACCESS_KEY: ${{ secrets.AWS_SES_ACCESS_KEY }}
+          AWS_SES_SECRET_KEY: ${{ secrets.AWS_SES_SECRET_KEY }}
+          AWS_SES_ADMIN_EMAIL: ${{ secrets.AWS_SES_ADMIN_EMAIL }}
         run: ./gradlew clean build --no-daemon -Dspring.profiles.active=prod
 
       # 6. JAR 파일 검증
@@ -65,6 +68,19 @@ jobs:
       # 7. ZIP 파일 생성
       - name: 📦 Create ZIP for CodeDeploy
         run: |
+          echo "AWS_RDS_URL=${{ secrets.AWS_RDS_URL }}" > .env
+          echo "AWS_RDS_USERNAME=${{ secrets.AWS_RDS_USERNAME }}" >> .env
+          echo "AWS_RDS_PASSWORD=${{ secrets.AWS_RDS_PASSWORD }}" >> .env
+          echo "AWS_REDIS_URL=${{ secrets.AWS_REDIS_URL }}" >> .env
+          echo "AWS_REDIS_PORT=${{ secrets.AWS_REDIS_PORT }}" >> .env
+          echo "CLIENT_ID=${{ secrets.CLIENT_ID }}" >> .env
+          echo "CLIENT_SECRET_KEY=${{ secrets.CLIENT_SECRET_KEY }}" >> .env
+          echo "AWS_S3_IMAGE_BUCKET=${{ secrets.AWS_S3_IMAGE_BUCKET }}" >> .env
+          echo "AWS_S3_ACCESS_KEY=${{ secrets.AWS_S3_ACCESS_KEY }}" >> .env
+          echo "AWS_S3_SECRET_KEY=${{ secrets.AWS_S3_SECRET_KEY }}" >> .env
+          echo "AWS_SES_ACCESS_KEY=${{ secrets.AWS_SES_ACCESS_KEY }}" >> .env
+          echo "AWS_SES_SECRET_KEY=${{ secrets.AWS_SES_SECRET_KEY }}" >> .env
+          echo "AWS_SES_ADMIN_EMAIL=${{ secrets.AWS_SES_ADMIN_EMAIL }}" >> .env
           zip -j ./$GITHUB_SHA.zip build/libs/picket.jar appspec.yml scripts/deploy.sh .env
         shell: bash
 

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -10,47 +10,41 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: 🧪 Run Gradle Build & Tests
-    services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_ROOT_PASSWORD: 1111
-          MYSQL_DATABASE: picket-mysql
-          MYSQL_USER: test
-          MYSQL_PASSWORD: test
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping --silent"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
+
     steps:
       # 1. 최신 코드 체크아웃
       - name: 📦 Checkout Repository
         uses: actions/checkout@v4
 
-      # 2. gradlew 실행 권한 부여
+      # 2. Docker Compose 설치
+      - name: 🐳 Install Docker Compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.24.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+
+      # 3. Docker Compose로 서비스 실행
+      - name: 🚀 Start Services with Docker Compose
+        run: |
+          docker-compose up -d
+          # 컨테이너가 완전히 준비될 때까지 대기
+          until docker-compose ps | grep -q "healthy"; do
+            echo "Waiting for services to be healthy..."
+            sleep 5
+          done
+
+      # 4. gradlew 실행 권한 부여
       - name: 🔐 Grant Execute Permission for gradlew
         run: chmod +x ./gradlew
 
-      # 3. Java/Gradle 환경 설정
+      # 5. Java/Gradle 환경 설정
       - name: ☕ Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      # 4. Gradle 캐시 설정
+      # 6. Gradle 캐시 설정
       - name: ⚡ Cache Gradle Dependencies
         uses: actions/cache@v4
         with:
@@ -61,6 +55,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 5. Gradle 빌드 실행
+      # 7. Gradle 빌드 실행
       - name: 🏗️ Build with Gradle
         run: ./gradlew clean build --no-daemon

--- a/src/main/java/com/example/picket/common/Controller/RedirectController.java
+++ b/src/main/java/com/example/picket/common/Controller/RedirectController.java
@@ -1,0 +1,13 @@
+package com.example.picket.common.Controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class RedirectController {
+
+    @GetMapping("/")
+    public String redirectToSwagger() {
+        return "redirect:/swagger-ui/index.html";
+    }
+}

--- a/src/main/java/com/example/picket/common/consts/Const.java
+++ b/src/main/java/com/example/picket/common/consts/Const.java
@@ -13,17 +13,17 @@ public interface Const {
                     "/api/v*/shows/*",
                     "/api/v*/shows/*/comments",
                     "/swagger-ui/*",
-                    "/v3/api-docs/**",
-                    "/api/v2/auth/session",
-                    "/api/v2/auth/callback/*",
-                    "/api/v2/auth/signup",
+                    "/v*/api-docs/**",
+                    "/api/v*/auth/session",
+                    "/api/v*/auth/callback/*",
+                    "/api/v*/auth/signup",
             },
             "POST", new String[]{
                     "/api/v*/auth/signup/*",
                     "/api/v*/auth/signin",
                     "/api/v*/auth/verify-code",
                     "/swagger-ui/*",
-                    "/v3/api-docs/**",
+                    "/v*/api-docs/**",
             },
             "PUT", new String[]{
 

--- a/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/picket/domain/auth/controller/AuthController.java
@@ -64,6 +64,14 @@ public class AuthController {
         }
     }
 
+    @Operation(summary = "회원가입(이메일 인증 X)", description = "유저 역할을 가진 회원가입 정보를 입력합니다. 특정 이메일만 인증이 가능하므로, 회원가입의 경우 해당 API 사용을 권장합니다.")
+    @PostMapping("/auth/signup/user/notemail")
+    public ResponseEntity<SignupResponse> signupUserWithoutVerify(@Valid @RequestBody SignupRequest request) {
+        authService.signup(request.getEmail(), request.getPassword(),
+                request.getNickname(), request.getBirth(), request.getGender(), UserRole.USER);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
     @Operation(summary = "로그인", description = "로그인을 할 수 있습니다.")
     @PostMapping("/auth/signin")
     public ResponseEntity<SigninResponse> signin(HttpSession session, HttpServletResponse response,

--- a/src/main/java/com/example/picket/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/picket/domain/auth/service/AuthService.java
@@ -115,6 +115,18 @@ public class AuthService {
         redisTemplate.delete("verified:" + email);
     }
 
+    public void signup(String email, String password, String nickname, LocalDate birth, Gender gender,
+                       UserRole userRole) {
+
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(BAD_REQUEST, "이미 가입되어있는 이메일입니다.");
+        }
+
+        User newUser = User.create(email, passwordEncoder.encode(password), userRole, null, nickname, birth, gender);
+
+        userRepository.save(newUser);
+    }
+
     public User signin(HttpSession session, HttpServletResponse response, String email, String password) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(NOT_FOUND, "해당 유저를 찾을 수 없습니다."));

--- a/src/main/java/com/example/picket/domain/show/dto/response/ShowImageResponse.java
+++ b/src/main/java/com/example/picket/domain/show/dto/response/ShowImageResponse.java
@@ -1,0 +1,17 @@
+package com.example.picket.domain.show.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class ShowImageResponse {
+
+    private final String profileUrl;
+
+    private ShowImageResponse(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    public static ShowImageResponse of(String profileUrl) {
+        return new ShowImageResponse(profileUrl);
+    }
+}

--- a/src/main/java/com/example/picket/domain/show/service/ShowCommandService.java
+++ b/src/main/java/com/example/picket/domain/show/service/ShowCommandService.java
@@ -17,10 +17,10 @@ import com.example.picket.domain.show.dto.request.ShowUpdateRequest;
 import com.example.picket.domain.show.entity.Show;
 import com.example.picket.domain.show.entity.ShowDate;
 import com.example.picket.domain.show.repository.ShowRepository;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -211,8 +211,8 @@ public class ShowCommandService {
     }
 
     //이미지 업로드
-    public String uploadImage(HttpServletRequest request) {
-        ImageResponse imageResponse = s3Service.upload(request);
+    public String uploadImage(MultipartFile multipartFile) {
+        ImageResponse imageResponse = s3Service.upload(multipartFile);
         ShowImage showImage = ShowImage.create(imageResponse, null);
         showImageRepository.save(showImage);
         return imageResponse.getImageUrl();

--- a/src/main/java/com/example/picket/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/picket/domain/user/controller/UserController.java
@@ -5,16 +5,20 @@ import com.example.picket.common.dto.AuthUser;
 import com.example.picket.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.picket.domain.user.dto.request.UpdateUserRequest;
 import com.example.picket.domain.user.dto.request.WithdrawUserRequest;
+import com.example.picket.domain.user.dto.response.UserImageResponse;
 import com.example.picket.domain.user.dto.response.UserResponse;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.service.UserCommandService;
 import com.example.picket.domain.user.service.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -61,9 +65,21 @@ public class UserController {
     }
 
     @Operation(summary = "유저 프로필 이미지 업로드", description = "유저 프로필 이미지 업로드 API입니다")
-    @PostMapping("/users/uploadImage")
-    public ResponseEntity<String> uploadImage(
-            HttpServletRequest request) {
-        return ResponseEntity.ok(userService.uploadImage(request));
+    @PostMapping(value = "/users/uploadImage", consumes = "multipart/form-data")
+    public ResponseEntity<UserImageResponse> uploadImage(@Parameter(
+            description = "업로드할 이미지 파일",
+            required = true,
+            name = "multipartFile",
+            content = @Content(
+                    mediaType = "multipart/form-data",
+                    schema = @Schema(
+                            type = "string",
+                            format = "binary",
+                            description = "지원 형식: JPEG, PNG, GIF, WEBP. 최대 크기: 8MB. 예: image.png",
+                            example = "image.png"
+                    )
+            )
+    ) @RequestParam("multipartFile") MultipartFile multipartFile) {
+        return ResponseEntity.ok(UserImageResponse.of(userService.uploadImage(multipartFile)));
     }
 }

--- a/src/main/java/com/example/picket/domain/user/dto/response/UserImageResponse.java
+++ b/src/main/java/com/example/picket/domain/user/dto/response/UserImageResponse.java
@@ -1,0 +1,17 @@
+package com.example.picket.domain.user.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UserImageResponse {
+
+    private final String profileUrl;
+
+    private UserImageResponse(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    public static UserImageResponse of(String profileUrl) {
+        return new UserImageResponse(profileUrl);
+    }
+}

--- a/src/main/java/com/example/picket/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/picket/domain/user/service/UserCommandService.java
@@ -12,10 +12,10 @@ import com.example.picket.domain.user.dto.request.UpdateUserRequest;
 import com.example.picket.domain.user.dto.request.WithdrawUserRequest;
 import com.example.picket.domain.user.entity.User;
 import com.example.picket.domain.user.repository.UserRepository;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 
@@ -81,9 +81,8 @@ public class UserCommandService {
         userRepository.delete(user);
     }
 
-    public String uploadImage(HttpServletRequest request) {
-
-        ImageResponse imageResponse = s3Service.upload(request);
+    public String uploadImage(MultipartFile multipartFile) {
+        ImageResponse imageResponse = s3Service.upload(multipartFile);
         UserImage userImage = UserImage.create(imageResponse, null);
         userImageRepository.save(userImage);
         return imageResponse.getImageUrl();

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,12 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   data:
     redis:
       host: localhost
@@ -28,17 +34,19 @@ spring:
       namespace: spring:session
     timeout: 60m
 
+#Google OAuth
 oauth:
   google:
     client-id: dummy-client-id
     client-secret: dummy-client-secret
-    redirect-uris :
+    redirect-uris:
       director: http://localhost:8080/api/v2/auth/callback/director
       user: http://localhost:8080/api/v2/auth/callback/user
       admin: http://localhost:8080/api/v2/auth/callback/admin
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
 
+# AWS S3
 cloud:
   aws:
     credentials:
@@ -51,6 +59,7 @@ cloud:
     stack:
       auto: false
 
+# AWS SES
 aws:
   region: ap-northeast-2
   ses:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,6 +18,12 @@ spring:
         format_sql: true
     open-in-view: false
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   data:
     redis:
       host: ${AWS_REDIS_URL}
@@ -34,6 +40,7 @@ spring:
       namespace: spring:session
     timeout: 60m
 
+#Google OAuth
 oauth:
   google:
     client-id: ${CLIENT_ID}
@@ -45,6 +52,7 @@ oauth:
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
 
+#AWS S3
 cloud:
   aws:
     credentials:
@@ -56,3 +64,11 @@ cloud:
       static: ${AWS_REGION}
     stack:
       auto: false
+
+#AWS SES
+aws:
+  region: ${AWS_REGION}
+  ses:
+    access-key: ${AWS_SES_ACCESS_KEY}
+    secret-key: ${AWS_SES_SECRET_KEY}
+    send-mail-from: ${AWS_SES_ADMIN_EMAIL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,12 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   data:
     redis:
       host: localhost
@@ -28,6 +34,7 @@ spring:
       namespace: spring:session
     timeout: 60m
 
+#Google OAuth
 oauth:
   google:
     client-id: ${CLIENT_ID}
@@ -50,6 +57,7 @@ server:
     mbeanregistry:
       enabled: true
 
+# AWS S3
 cloud:
   aws:
     credentials:
@@ -62,9 +70,10 @@ cloud:
     stack:
       auto: false
 
+# AWS SES
 aws:
   region: ${AWS_REGION}
   ses:
-    access-key: ${AWS_ACCESS_KEY}
-    secret-key: ${AWS_SECRET_KEY}
-    send-mail-from: ${ADMIN_EMAIL}
+    access-key: ${AWS_SES_ACCESS_KEY}
+    secret-key: ${AWS_SES_SECRET_KEY}
+    send-mail-from: ${AWS_SES_ADMIN_EMAIL}

--- a/src/test/java/com/example/picket/common/service/S3ServiceTest.java
+++ b/src/test/java/com/example/picket/common/service/S3ServiceTest.java
@@ -3,7 +3,6 @@ package com.example.picket.common.service;
 import com.example.picket.common.exception.CustomException;
 import com.example.picket.domain.images.dto.response.ImageResponse;
 import jakarta.servlet.ServletInputStream;
-import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.DelegatingServletInputStream;
+import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -40,7 +40,7 @@ class S3ServiceTest {
     S3Client s3Client;
 
     @Mock
-    HttpServletRequest request;
+    MultipartFile multipartFile;
 
     @InjectMocks
     S3Service s3Service;
@@ -61,10 +61,10 @@ class S3ServiceTest {
         @Test
         void 이미지_업로드_시_확장자가_null일_경우_실패() {
             // given
-            given(request.getContentType()).willReturn(null);
+            given(multipartFile.getContentType()).willReturn(null);
 
             // when & then
-            assertThatThrownBy(() -> s3Service.upload(request))
+            assertThatThrownBy(() -> s3Service.upload(multipartFile))
                     .isInstanceOf(CustomException.class)
                     .hasMessage("지원되지 않는 파일 형식입니다. 허용 Content-Type: " + ALLOWED_CONTENT_TYPES);
         }
@@ -72,10 +72,10 @@ class S3ServiceTest {
         @Test
         void 이미지_업로드_시_확장자가_지원되는_타입이_아닐_경우_실패() {
             // given
-            given(request.getContentType()).willReturn(null);
+            given(multipartFile.getContentType()).willReturn(null);
 
             // when & then
-            assertThatThrownBy(() -> s3Service.upload(request))
+            assertThatThrownBy(() -> s3Service.upload(multipartFile))
                     .isInstanceOf(CustomException.class)
                     .hasMessage("지원되지 않는 파일 형식입니다. 허용 Content-Type: " + ALLOWED_CONTENT_TYPES);
         }
@@ -83,10 +83,10 @@ class S3ServiceTest {
         @Test
         void 이미지_업로드_시_파일_크기가_8MB보다_클_경우_실패() {
             // given
-            given(request.getContentType()).willReturn("image/jpeg");
-            given(request.getContentLength()).willReturn(10 * 1024 * 1024);
+            given(multipartFile.getContentType()).willReturn("image/jpeg");
+            given(multipartFile.getSize()).willReturn((long) (10 * 1024 * 1024));
             // when & then
-            assertThatThrownBy(() -> s3Service.upload(request))
+            assertThatThrownBy(() -> s3Service.upload(multipartFile))
                     .isInstanceOf(CustomException.class)
                     .hasMessage("파일 크기가 8MB를 초과했습니다. 최대 크기: " + MAX_FILE_SIZE / (1024 * 1024) + "MB");
         }
@@ -99,32 +99,32 @@ class S3ServiceTest {
             ImageIO.write(image, "jpeg", baos);
             byte[] imageBytes = baos.toByteArray();
 
-            HttpServletRequest spyRequest = Mockito.spy(HttpServletRequest.class);
+            MultipartFile spyFile = Mockito.spy(MultipartFile.class);
             ServletInputStream servletInputStream = new DelegatingServletInputStream(
                     new ByteArrayInputStream(imageBytes));
-            doReturn("image/jpeg").when(spyRequest).getContentType();
-            doReturn(servletInputStream).when(spyRequest).getInputStream();
+            doReturn("image/jpeg").when(spyFile).getContentType();
+            doReturn(servletInputStream).when(spyFile).getInputStream();
 
             when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
                     .thenThrow(SdkServiceException.builder().message("S3 upload failed").build());
 
             // when & then
-            assertThatThrownBy(() -> s3Service.upload(spyRequest))
+            assertThatThrownBy(() -> s3Service.upload(spyFile))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining("S3 업로드 중 오류가 발생했습니다");
             verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
-            verify(spyRequest, times(1)).getInputStream();
+            verify(spyFile, times(1)).getInputStream();
         }
 
         @Test
         void 이미지_업로드_시_파일_업로드_중_IOException_발생할_경우_실패() throws IOException {
             // given
-            given(request.getContentType()).willReturn("image/jpeg");
-            given(request.getContentLength()).willReturn(5 * 1024 * 1024);
-            when(request.getInputStream()).thenThrow(new IOException("Input stream error"));
+            given(multipartFile.getContentType()).willReturn("image/jpeg");
+            given(multipartFile.getSize()).willReturn((long) (5 * 1024 * 1024));
+            when(multipartFile.getInputStream()).thenThrow(new IOException("Input stream error"));
 
             // when & then
-            assertThatThrownBy(() -> s3Service.upload(request))
+            assertThatThrownBy(() -> s3Service.upload(multipartFile))
                     .isInstanceOf(CustomException.class)
                     .hasMessage("파일 업로드 중 서버 오류가 발생했습니다: Input stream error");
         }
@@ -137,14 +137,14 @@ class S3ServiceTest {
             ImageIO.write(image, "jpeg", baos);
             byte[] imageBytes = baos.toByteArray();
 
-            HttpServletRequest spyRequest = Mockito.spy(HttpServletRequest.class);
+            MultipartFile spyFile = Mockito.spy(MultipartFile.class);
             ServletInputStream servletInputStream = new DelegatingServletInputStream(
                     new ByteArrayInputStream(imageBytes));
-            doReturn("image/jpeg").when(spyRequest).getContentType();
-            doReturn(servletInputStream).when(spyRequest).getInputStream();
+            doReturn("image/jpeg").when(spyFile).getContentType();
+            doReturn(servletInputStream).when(spyFile).getInputStream();
 
             // when
-            ImageResponse imageResponse = s3Service.upload(spyRequest);
+            ImageResponse imageResponse = s3Service.upload(spyFile);
 
             // then
             assertThat(imageResponse).isNotNull();
@@ -152,7 +152,7 @@ class S3ServiceTest {
                     String.format("https://null.s3.null.amazonaws.com/images/"));
             assertThat(imageResponse.getFileFormat()).isEqualTo(VALID_CONTENT_TYPE);
             verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
-            verify(spyRequest, times(1)).getInputStream();
+            verify(spyFile, times(1)).getInputStream();
         }
 
     }


### PR DESCRIPTION
📌 반영 브랜치
refactor/image -> dev

✅ 작업 내용
- 회원가입 시 이메일 인증 없이 회원 가입 가능한 메서드 추가(AWS SES에서 특정 이메일로만 인증이 가능하기 때문)
- S3 업로드 방식 기존 Stream 방식에서 MultipartFile 방식으로 변경
- deploy.yml 에 env 파일 삽입 추가
- pullrequest.yml 에서 docker-compose up으로 변경
- application.yml 파일들 주석 생성

🎯 단독 테스트 결과
- 단위 테스트 TestCode 통해 확인
- PostMan 통해 통합 테스트 확인 완료
- Swagger 통해 테스트 확인 완료

🚨 연관 이슈
closes #132  