### PR TITLE
Payment : 화면 렌더링 시 orderId 보여주도록 수정

### DIFF
--- a/src/main/resources/static/checkout.html
+++ b/src/main/resources/static/checkout.html
@@ -9,6 +9,10 @@
 <div id="payment-method"></div>
 <!-- 이용약관 UI -->
 <div id="agreement"></div>
+<!-- 주문 ID 표시 -->
+<div style="margin-top:20px;">
+    <strong>주문 ID:</strong> <span id="order-id"></span>
+</div>
 <!-- 결제하기 버튼 -->
 <button class="button" id="payment-button" style="margin-top: 30px">결제하기</button>
 
@@ -27,6 +31,7 @@
     async function main() {
         const button = document.getElementById("payment-button");
         const coupon = document.getElementById("coupon-box");
+        const orderIdSpan = document.getElementById("order-id"); // 추가: order-id span 가져오기
         // ------  결제위젯 초기화 ------
         const clientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
         const tossPayments = TossPayments(clientKey);
@@ -55,9 +60,13 @@
             widgets.renderAgreement({ selector: "#agreement", variantKey: "AGREEMENT" }),
         ]);
 
+        // 페이지 로드 시 orderId 미리 생성하고 보여주기
+        let currentOrderId = generateRandomOrderId();
+        orderIdSpan.textContent = currentOrderId;
+
         // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
         button.addEventListener("click", async function () {
-            const orderId = generateRandomOrderId();
+            const orderId = currentOrderId;
             await widgets.requestPayment({
                 orderId: orderId,
                 orderName: "2026 FIFA 월드컵 아시아 3차 예선 요르단전 수원월드컵경기장 E17",


### PR DESCRIPTION
📌 반영 브랜치
feat/payment -> dev

✅ 작업 내용

기존에 결제 요청 후 쿼리파라미터로 받은 orderId와 amount 값으로 결제정보 임시저장 API 호출하는 잘못된 방법으로 테스트 중 이었습니다.
쿼리 파라미터로 받은 값을 임시저장 하는 것이 아니라 결제 요청 전 정보를 임시저장 해야하므로 다음과 같이 수정하였습니다.

프론트 엔드에서 결제 요청 전 orderId와 amount 정보를 임시저장 해야하므로 checkout.html 파일 렌더링 시 orderId를 화면에 그려주고 결제정보 임시저장 API 호출하도록 수정하였습니다.

해당 결제 과정에 이해를 돕기 위해 블로그를 참고하시면 좋을 것 같습니다.
https://yubin-code.tistory.com/5

🎯 단독 테스트 결과
Swagger 통해 테스트 확인 완료

🚨 연관 이슈
closes #125